### PR TITLE
Auto-unlock, stat editor, and unlock queue

### DIFF
--- a/XAU/App.xaml.cs
+++ b/XAU/App.xaml.cs
@@ -32,6 +32,8 @@ public partial class App
             services.AddSingleton<GamesViewModel>();
             services.AddSingleton<AchievementsPage>();
             services.AddSingleton<AchievementsViewModel>();
+            services.AddSingleton<QueuePage>();
+            services.AddSingleton<QueueViewModel>();
             services.AddSingleton<PlaceholderPage>();
             services.AddSingleton<StatsPage>();
             services.AddSingleton<StatsViewModel>();
@@ -43,7 +45,7 @@ public partial class App
             services.AddSingleton<DebugViewModel>();
         }).Build();
 
-    private static T? GetService<T>() where T : class
+    public static T? GetService<T>() where T : class
     {
         return Host.Services.GetService(typeof(T)) as T;
     }

--- a/XAU/Models/AutoUnlock.cs
+++ b/XAU/Models/AutoUnlock.cs
@@ -1,0 +1,113 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace XAU.AutoUnlock
+{
+    public enum UnlockCategory
+    {
+        None,
+        Easy,
+        Hard
+    }
+
+    public static class CategoryDetector
+    {
+        public const string LabelEasy = "Easy Unlock";
+        public const string LabelHard = "Hard Unlock";
+
+        public static bool HasRequests(JToken? achievementData)
+        {
+            if (achievementData is not JObject obj)
+                return false;
+
+            foreach (var prop in obj.Properties())
+            {
+                if (prop.Name.StartsWith("Request", System.StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+
+        public static bool HasDirectReplacements(JToken? achievementData)
+        {
+            if (achievementData is not JObject obj)
+                return false;
+
+            return obj["EventReplacement"] != null
+                || obj["DataReplacement"] != null
+                || obj["MetaDataReplacement"] != null;
+        }
+
+        public static UnlockCategory Detect(JToken? achievementData)
+        {
+            if (achievementData is not JObject)
+                return UnlockCategory.None;
+
+            if (HasRequests(achievementData) || HasDirectReplacements(achievementData))
+                return UnlockCategory.Hard;
+
+            return UnlockCategory.Easy;
+        }
+
+        public static string Label(UnlockCategory category)
+        {
+            return category switch
+            {
+                UnlockCategory.Easy => LabelEasy,
+                UnlockCategory.Hard => LabelHard,
+                _ => string.Empty
+            };
+        }
+    }
+
+    public class UnlockOrderItem
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public long DelaySeconds { get; set; }
+        public int Gamerscore { get; set; }
+    }
+
+    public class UnlockOrder
+    {
+        public string TitleId { get; set; } = "";
+        public string GameName { get; set; } = "";
+        public string ReferenceGamertag { get; set; } = "";
+        public System.DateTime GeneratedAt { get; set; }
+
+        public System.Collections.Generic.List<UnlockOrderItem> Items { get; set; }
+            = new System.Collections.Generic.List<UnlockOrderItem>();
+
+        [JsonIgnore]
+        public long TotalDurationSeconds
+        {
+            get
+            {
+                long total = 0;
+                foreach (var item in Items)
+                    total += item.DelaySeconds;
+                return total;
+            }
+        }
+    }
+
+    public class AutoUnlockState
+    {
+        public string TitleId { get; set; } = "";
+        public int Index { get; set; }
+        public string AchievementId { get; set; } = "";
+        public string AchievementName { get; set; } = "";
+        public System.DateTime TargetTimeUtc { get; set; }
+    }
+
+    public class AutoProgress
+    {
+        public int Index { get; set; }
+        public int Total { get; set; }
+        public string GameName { get; set; } = "";
+        public string AchievementName { get; set; } = "";
+        public long SecondsRemaining { get; set; }
+        public string Message { get; set; } = "";
+        public bool Completed { get; set; }
+    }
+}

--- a/XAU/Models/XboxApiRequest.cs
+++ b/XAU/Models/XboxApiRequest.cs
@@ -1,4 +1,4 @@
-// TODO: Clean up, set names, default fields, minor renames, etc.
+// TODO: limpar, ajustar nomes, campos default, renomeações menores, etc.
 
 public class GameTitleRequest
 {
@@ -37,8 +37,15 @@ public class GameStatsRequest
 
 public class HeartbeatRequest
 {
-    public long id { get; set; }
-    public string State { get; set; } = "Active";
+    public List<TitleRequest> titles { get; set; } = new List<TitleRequest>();
+}
+
+public class TitleRequest
+{
+    public int expiration { get; set; } = 600;
+    public string? id { get; set; }
+    public string state { get; set; } = "active";
+    public string sandbox { get; set; } = "RETAIL";
 }
 
 public class GamepassProductsRequest

--- a/XAU/Networking/XboxRestApi.cs
+++ b/XAU/Networking/XboxRestApi.cs
@@ -11,11 +11,10 @@ public class XboxRestAPI
 {
     private readonly HttpClient _httpClient;
 
-    private readonly HttpClient _eventBasedClient; // Dumb, but needed for events for now
+    private readonly HttpClient _eventBasedClient; // burro, mas necessário pros eventos por enquanto
 
     private readonly HttpClient _spooferClient;
 
-    // User specifics
     private readonly string _xauth;
     private readonly string _requestedResponseLanguage;
 
@@ -33,10 +32,22 @@ public class XboxRestAPI
         var insecureEventsHandler = new HttpClientHandler()
         {
             AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate,
-            //This is an absolutely terrible idea but the stupid fucking events API just cries about SSL errors
+            // Péssima ideia, mas a API de eventos só reclama de erros de SSL sem isto
             ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
         };
         _eventBasedClient = new HttpClient(insecureEventsHandler);
+    }
+
+    // Serializa chamadas que compartilham o DefaultRequestHeaders mutável, pra que
+    // operações concorrentes (ex.: o loop de spoof sobrepondo um refresh) não corrompam
+    // os headers uma da outra no meio do request — o que causava os 403 de spoof.
+    private readonly SemaphoreSlim _gate = new SemaphoreSlim(1, 1);
+
+    private async Task Gated(Func<Task> fn)
+    {
+        await _gate.WaitAsync();
+        try { await fn(); }
+        finally { _gate.Release(); }
     }
 
     private void SetDefaultHeaders()
@@ -127,7 +138,6 @@ public class XboxRestAPI
     {
         if (string.IsNullOrWhiteSpace(xuid) || string.IsNullOrWhiteSpace(titleId))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
 
@@ -148,7 +158,6 @@ public class XboxRestAPI
     {
         if (string.IsNullOrWhiteSpace(xuid))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
 
@@ -162,7 +171,6 @@ public class XboxRestAPI
     {
         if (string.IsNullOrWhiteSpace(xuid))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
 
@@ -171,8 +179,8 @@ public class XboxRestAPI
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Host, Hosts.TitleHub);
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Connection, HeaderValues.KeepAlive);
         var responseString = await _httpClient.GetStringAsync(string.Format(InterpolatedXboxAPIUrls.TitlesUrl, xuid));
-        // Parsing thousands of titles is CPU-bound; run it off the captured
-        // (UI) synchronization context so the caller's UI thread stays responsive.
+        // Parsear milhares de títulos é CPU-bound; roda fora do contexto de sincronização
+        // (UI) capturado pra manter a thread de UI do chamador responsiva.
         return await Task.Run(() => JsonConvert.DeserializeObject<TitlesList>(responseString));
     }
 
@@ -180,7 +188,6 @@ public class XboxRestAPI
     {
         if (string.IsNullOrWhiteSpace(gamertag))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
 
@@ -199,7 +206,6 @@ public class XboxRestAPI
     {
         if (string.IsNullOrWhiteSpace(xuid) || string.IsNullOrWhiteSpace(titleId))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
 
@@ -221,46 +227,46 @@ public class XboxRestAPI
         return JsonConvert.DeserializeObject<GameStatsResponse>(response);
     }
 
-    public async Task SendHeartbeatAsync(string xuid, string spoofedTitleId)
+    // Heartbeat de presença único e limpo (o fluxo provado pré-schlop), serializado pelo
+    // gate pra que ticks sobrepostos do loop não corrompam os headers compartilhados. É o
+    // token enrolled do app Xbox (GDK) em _xauth que faz o presence-heartbeat aceitar.
+    public Task SendHeartbeatAsync(string xuid, string spoofedTitleId) => Gated(async () =>
     {
-        if (string.IsNullOrWhiteSpace(xuid) || string.IsNullOrWhiteSpace(spoofedTitleId) || !long.TryParse(spoofedTitleId, out var numericId))
+        if (string.IsNullOrWhiteSpace(xuid) || string.IsNullOrWhiteSpace(spoofedTitleId))
             return;
-
-        var url = string.Format(InterpolatedXboxAPIUrls.HeartbeatUrl, xuid);
-        var body = JsonConvert.SerializeObject(new HeartbeatRequest { id = numericId });
-        var signature = XAU.Services.WamAuthService.SignRequest("POST", url, body);
 
         SetDefaultSpooferHeaders();
         _spooferClient.DefaultRequestHeaders.Add(HeaderNames.ContractVersion, HeaderValues.ContractVersion3);
-        _spooferClient.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
-        if (signature != null)
-            _spooferClient.DefaultRequestHeaders.Add("Signature", signature);
+        var heartbeatRequest = new HeartbeatRequest()
+        {
+            titles = new List<TitleRequest>()
+            {
+                new TitleRequest()
+                {
+                    id = spoofedTitleId
+                }
+            }
+        };
+        var resp = await _spooferClient.PostAsync(
+            string.Format(InterpolatedXboxAPIUrls.HeartbeatUrl, xuid),
+            new StringContent(JsonConvert.SerializeObject(heartbeatRequest), Encoding.UTF8, HeaderValues.Accept));
+        XAU.Services.WamAuthService.Diag(resp.IsSuccessStatusCode ? "spoof OK" : $"spoof {(int)resp.StatusCode}: {await resp.Content.ReadAsStringAsync()}");
+    });
 
-        await _spooferClient.PostAsync(url,
-            new StringContent(body, Encoding.UTF8, "application/json"));
-    }
-
-    public async Task StopHeartbeatAsync(string xuid)
+    public Task StopHeartbeatAsync(string xuid) => Gated(async () =>
     {
         if (string.IsNullOrWhiteSpace(xuid))
             return;
 
-        var url = string.Format(InterpolatedXboxAPIUrls.HeartbeatUrl, xuid);
-        var signature = XAU.Services.WamAuthService.SignRequest("DELETE", url, "");
-
         SetDefaultSpooferHeaders();
         _spooferClient.DefaultRequestHeaders.Add(HeaderNames.ContractVersion, HeaderValues.ContractVersion3);
-        if (signature != null)
-            _spooferClient.DefaultRequestHeaders.Add("Signature", signature);
-
-        await _spooferClient.DeleteAsync(url);
-    }
+        await _spooferClient.DeleteAsync(string.Format(InterpolatedXboxAPIUrls.HeartbeatUrl, xuid));
+    });
 
     public async Task<AchievementsResponse?> GetAchievementsForTitleAsync(string xuid, string titleId)
     {
         if (string.IsNullOrWhiteSpace(xuid) || string.IsNullOrWhiteSpace(titleId))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
         SetDefaultHeaders();
@@ -278,7 +284,6 @@ public class XboxRestAPI
     {
         if (string.IsNullOrWhiteSpace(xuid) || string.IsNullOrWhiteSpace(titleId))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
         SetDefaultHeaders();
@@ -293,7 +298,6 @@ public class XboxRestAPI
 
     public async Task UnlockTitleBasedAchievementAsync(string serviceConfigId, string titleId, string xuid, string achievementId)
     {
-        // only unlock the specified achievement
         await UnlockTitleBasedAchievementsAsync(serviceConfigId, titleId, xuid, new List<string>() { achievementId });
     }
 
@@ -301,7 +305,6 @@ public class XboxRestAPI
     {
         if (string.IsNullOrWhiteSpace(serviceConfigId) || string.IsNullOrWhiteSpace(titleId) || string.IsNullOrWhiteSpace(xuid) || achievementIds.Count == 0)
         {
-            // Don't send a request if we don't have the details
             return;
         }
 
@@ -311,8 +314,8 @@ public class XboxRestAPI
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Connection, HeaderValues.KeepAlive);
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "XboxServicesAPI/2021.10.20211005.0 c");
 
-        // Split the requests into 50 achievements each. Anything over 100 seems to BadRequest. TODO: look into
-        // headers and see if we can send long data or w/e
+        // Divide os requests em 50 achievements cada. Acima de 100 parece dar BadRequest.
+        // TODO: investigar os headers pra ver se dá pra mandar mais de uma vez.
         const int chunkSize = 50;
         for (int i = 0; i < achievementIds.Count; i += chunkSize)
         {
@@ -332,6 +335,8 @@ public class XboxRestAPI
             if (signature != null)
                 _httpClient.DefaultRequestHeaders.Add(HeaderNames.Signature, signature);
 
+            // Fica abaixo dos rate limits finos do Xbox quando o auto-unlocker manda muitos chunks.
+            await XAU.Services.AutoUnlock.XboxRateLimiter.Achievements.WaitAsync(System.Threading.CancellationToken.None);
             var response = await _httpClient.PostAsync(url,
                 new StringContent(unlockBodyStr, Encoding.UTF8, HeaderValues.Accept));
             if (signature != null)
@@ -339,17 +344,19 @@ public class XboxRestAPI
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
+                var unlockBody = await response.Content.ReadAsStringAsync();
+                XAU.Services.WamAuthService.Diag($"unlock {(int)response.StatusCode}: {unlockBody}");
                 throw new HttpRequestException($"Failed to unlock achievement(s) for title {titleId} with status code {response.StatusCode}");
             }
+            XAU.Services.WamAuthService.Diag("unlock OK");
         }
     }
 
-    // TODO: see if we can handle the actual request body building
+    // TODO: ver se dá pra montar o corpo do request aqui mesmo
     public async Task UnlockEventBasedAchievement(string eventsToken, StringContent requestBody)
     {
         if (string.IsNullOrWhiteSpace(eventsToken))
         {
-            // Don't send a request if we don't have the details
             return;
         }
 
@@ -367,11 +374,32 @@ public class XboxRestAPI
         }
     }
 
+    // Posta um batch de telemetria NDJSON cru e retorna o status HTTP (0 em falha).
+    // Usado pelo EventUnlocker / CounterUnlocker do auto-unlocker, que montam seus próprios
+    // corpos multi-evento e precisam do status pra decidir o ritmo/retries.
+    public async Task<int> SendEventBatchAsync(string eventsToken, string ndjsonBody)
+    {
+        if (string.IsNullOrWhiteSpace(eventsToken))
+            return 0;
+
+        SetDefaultEventBasedHeaders();
+        _eventBasedClient.DefaultRequestHeaders.Add("tickets", $"\"1\"=\"{eventsToken}\"");
+        try
+        {
+            var content = new StringContent(ndjsonBody, Encoding.UTF8, "application/x-json-stream");
+            var resp = await _eventBasedClient.PostAsync(BasicXboxAPIUris.TelemetryUrl, content);
+            return (int)resp.StatusCode;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
     public async Task<GamePassProducts?> GetTitleIdsFromGamePass(string prodId)
     {
         if (string.IsNullOrWhiteSpace(prodId))
         {
-            // Don't send a request if we don't have the details
             return null;
         }
 

--- a/XAU/Services/AutoUnlock/AutoUnlocker.cs
+++ b/XAU/Services/AutoUnlock/AutoUnlocker.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using XAU.AutoUnlock;
+
+namespace XAU.Services.AutoUnlock
+{
+    public class AutoUnlocker
+    {
+        private readonly string _titleId;
+
+        public AutoUnlocker(string titleId)
+        {
+            _titleId = titleId;
+        }
+
+        public async Task RunAsync(
+            UnlockOrder order,
+            Func<UnlockOrderItem, Task<bool>> unlockItem,
+            HashSet<string> alreadyUnlocked,
+            Action<AutoProgress> report,
+            Func<bool> isPaused,
+            CancellationToken token)
+        {
+            int total = order.Items.Count;
+
+            int start = 0;
+            long remainingWait = -1;
+            var state = OrderRepository.LoadState(_titleId);
+            if (state != null
+                && state.TitleId == _titleId
+                && state.Index >= 0
+                && state.Index < total
+                && order.Items[state.Index].Id == state.AchievementId)
+            {
+                start = state.Index;
+                var missing = (state.TargetTimeUtc - DateTime.UtcNow).TotalSeconds;
+                remainingWait = missing > 0 ? (long)Math.Ceiling(missing) : 0;
+            }
+
+            for (int i = start; i < total; i++)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    Report(report, order, i, total, "", -1, "Stopped", false);
+                    return;
+                }
+
+                var item = order.Items[i];
+
+                if (alreadyUnlocked.Contains(item.Id))
+                    continue;
+
+                long delay;
+                if (i == start && remainingWait >= 0)
+                {
+                    delay = remainingWait;
+                    remainingWait = -1;
+                }
+                else
+                {
+                    delay = item.DelaySeconds;
+                }
+
+                var target = DateTime.UtcNow.AddSeconds(delay);
+
+                OrderRepository.SaveState(new AutoUnlockState
+                {
+                    TitleId = _titleId,
+                    Index = i,
+                    AchievementId = item.Id,
+                    AchievementName = item.Name,
+                    TargetTimeUtc = target
+                });
+
+                while (DateTime.UtcNow < target)
+                {
+                    if (token.IsCancellationRequested)
+                    {
+                        Report(report, order, i, total, item.Name, -1, "Stopped", false);
+                        return;
+                    }
+
+                    if (isPaused())
+                    {
+                        target = target.AddSeconds(1);
+                        var frozen = (long)Math.Ceiling((target - DateTime.UtcNow).TotalSeconds);
+                        Report(report, order, i + 1, total, item.Name, Math.Max(0, frozen), "Paused", false);
+                        try { await Task.Delay(1000, token); }
+                        catch (OperationCanceledException)
+                        {
+                            Report(report, order, i, total, item.Name, -1, "Stopped", false);
+                            return;
+                        }
+                        continue;
+                    }
+
+                    var remaining = (long)Math.Ceiling((target - DateTime.UtcNow).TotalSeconds);
+                    Report(report, order, i + 1, total, item.Name, Math.Max(0, remaining), "", false);
+
+                    try
+                    {
+                        await Task.Delay(1000, token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        Report(report, order, i, total, item.Name, -1, "Stopped", false);
+                        return;
+                    }
+                }
+
+                while (isPaused() && !token.IsCancellationRequested)
+                {
+                    Report(report, order, i + 1, total, item.Name, 0, "Paused", false);
+                    try { await Task.Delay(1000, token); }
+                    catch (OperationCanceledException)
+                    {
+                        Report(report, order, i, total, item.Name, -1, "Stopped", false);
+                        return;
+                    }
+                }
+                if (token.IsCancellationRequested)
+                {
+                    Report(report, order, i, total, item.Name, -1, "Stopped", false);
+                    return;
+                }
+
+                Report(report, order, i + 1, total, item.Name, -1, "Unlocking", false);
+                bool success;
+                try
+                {
+                    success = await unlockItem(item);
+                }
+                catch
+                {
+                    success = false;
+                }
+
+                if (!success)
+                {
+                    Report(report, order, i + 1, total, item.Name, -1, $"Failed on: {item.Name}", true);
+                    return;
+                }
+
+                alreadyUnlocked.Add(item.Id);
+
+                if (i + 1 < total)
+                {
+                    var next = order.Items[i + 1];
+                    OrderRepository.SaveState(new AutoUnlockState
+                    {
+                        TitleId = _titleId,
+                        Index = i + 1,
+                        AchievementId = next.Id,
+                        AchievementName = next.Name,
+                        TargetTimeUtc = DateTime.UtcNow.AddSeconds(next.DelaySeconds)
+                    });
+                }
+            }
+
+            OrderRepository.ClearState(_titleId);
+            Report(report, order, total, total, "", -1, "Completed", true);
+        }
+
+        private static void Report(
+            Action<AutoProgress> report,
+            UnlockOrder order,
+            int index,
+            int total,
+            string achievementName,
+            long secondsRemaining,
+            string message,
+            bool completed)
+        {
+            report(new AutoProgress
+            {
+                Index = index,
+                Total = total,
+                GameName = order.GameName,
+                AchievementName = achievementName,
+                SecondsRemaining = secondsRemaining,
+                Message = message,
+                Completed = completed
+            });
+        }
+    }
+}

--- a/XAU/Services/AutoUnlock/CounterUnlocker.cs
+++ b/XAU/Services/AutoUnlock/CounterUnlocker.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Newtonsoft.Json.Linq;
+
+namespace XAU.Services.AutoUnlock
+{
+    public enum CounterResult
+    {
+        NotCounter, // sem requisito numérico alvo > 1
+        Achieved,
+        Pending,    // enviado, mas não confirmado a tempo (pode cair depois)
+        Failed
+    }
+
+    // Sonda 1 evento, mede o incremento real e recalcula o lote a cada rodada para
+    // convergir no alvo com poucos eventos sem estourar quando o passo é fracionado.
+    public sealed class CounterUnlocker
+    {
+        private const int MaxTotalEvents = 10000;
+        private const int MaxEventsPerRound = 2000;
+        private const int MaxRounds = 8;
+        private const int MaxStallRounds = 2;
+        private static readonly TimeSpan HardTimeout = TimeSpan.FromMinutes(8);
+        private static readonly int[] VerifyBackoff = { 3, 5, 8, 12 };
+
+        private readonly XboxRestAPI _api;
+        private readonly string _titleId;
+        private readonly string _xuid;
+        private readonly string _eventsToken;
+
+        public CounterUnlocker(XboxRestAPI api, string titleId, string xuid, string eventsToken)
+        {
+            _api = api;
+            _titleId = titleId;
+            _xuid = xuid;
+            _eventsToken = eventsToken;
+        }
+
+        public async Task<CounterResult> RunAsync(string achievementId, JObject gameData, CancellationToken token)
+        {
+            var snap = await ReadAsync(achievementId, token);
+            if (snap == null)
+                return CounterResult.NotCounter;
+            if (snap.Achieved)
+                return CounterResult.Achieved;
+            if (snap.Target <= 1)
+                return CounterResult.NotCounter;
+
+            var events = new EventUnlocker(_api, _titleId, _xuid, _eventsToken);
+            var started = DateTime.UtcNow;
+
+            long current = snap.Current;
+            long target = snap.Target;
+            long sent = 0;
+
+            // Sonda: 1 evento para medir o incremento.
+            if (!await TrySendAsync(events, achievementId, gameData, 1))
+                return CounterResult.Failed;
+            sent += 1;
+
+            var probed = await VerifyAsync(achievementId, token, 0);
+            if (probed == null) return CounterResult.Pending;
+            if (probed.Achieved || probed.Current >= target) return CounterResult.Achieved;
+
+            // Maximum/Minimum não acumulam: lote não adianta.
+            if (snap.IsSingleShot)
+                return CounterResult.Pending;
+
+            double perEvent = Math.Max(0, probed.Current - current);
+            current = probed.Current;
+
+            int stall = 0;
+            for (int round = 0; round < MaxRounds; round++)
+            {
+                if (token.IsCancellationRequested) return CounterResult.Pending;
+                if (DateTime.UtcNow - started > HardTimeout) return CounterResult.Pending;
+                if (sent >= MaxTotalEvents) break;
+
+                long remaining = target - current;
+                if (remaining <= 0) break;
+
+                // Sem incremento medido: assume +1/evento.
+                double step = perEvent > 0 ? perEvent : 1;
+                long toSend = (long)Math.Ceiling(remaining / step);
+                toSend = Math.Clamp(toSend, 1, Math.Min(MaxEventsPerRound, MaxTotalEvents - sent));
+
+                if (!await TrySendAsync(events, achievementId, gameData, (int)toSend))
+                    return current > snap.Current ? CounterResult.Pending : CounterResult.Failed;
+                sent += toSend;
+
+                var after = await VerifyAsync(achievementId, token, round);
+                if (after == null) return CounterResult.Pending;
+                if (after.Achieved || after.Current >= target) return CounterResult.Achieved;
+
+                long moved = after.Current - current;
+                if (moved > 0)
+                {
+                    perEvent = (double)moved / toSend;
+                    current = after.Current;
+                    stall = 0;
+                }
+                else if (++stall >= MaxStallRounds)
+                {
+                    break; // não anda mais; não é puramente contador
+                }
+            }
+
+            var final = await ReadAsync(achievementId, token);
+            return (final?.Achieved ?? false) ? CounterResult.Achieved : CounterResult.Pending;
+        }
+
+        private static async Task<bool> TrySendAsync(EventUnlocker events, string achievementId, JObject gameData, int count)
+        {
+            try { await events.SendEventsAsync(achievementId, gameData, count); return true; }
+            catch { return false; }
+        }
+
+        private async Task<Snapshot?> VerifyAsync(string achievementId, CancellationToken token, int round)
+        {
+            var seconds = VerifyBackoff[Math.Min(round, VerifyBackoff.Length - 1)];
+            try { await Task.Delay(TimeSpan.FromSeconds(seconds), token); }
+            catch (OperationCanceledException) { return null; }
+            return await ReadAsync(achievementId, token);
+        }
+
+        private async Task<Snapshot?> ReadAsync(string achievementId, CancellationToken token)
+        {
+            try
+            {
+                await XboxRateLimiter.Achievements.WaitAsync(token);
+                var resp = await _api.GetAchievementsForTitleAsync(_xuid, _titleId);
+                var ach = resp?.achievements?.FirstOrDefault(a => a.id == achievementId);
+                if (ach == null) return null;
+
+                bool achieved = ach.progressState == StringConstants.Achieved;
+
+                // Gargalo: o requisito numérico mais longe do alvo.
+                var reqs = ach.progression?.requirements?
+                    .Where(r => long.TryParse(r.target, out var t) && t > 1)
+                    .ToList();
+                if (reqs == null || reqs.Count == 0)
+                    return achieved ? new Snapshot(0, 1, true, false) : null;
+
+                var bottleneck = reqs
+                    .Select(r =>
+                    {
+                        long.TryParse(r.target, out var tg);
+                        long.TryParse(r.current, out var cu);
+                        return (cu, tg, op: r.operationType ?? "");
+                    })
+                    .OrderByDescending(x => x.tg - x.cu)
+                    .First();
+
+                bool single = bottleneck.op.Equals("Maximum", StringComparison.OrdinalIgnoreCase)
+                           || bottleneck.op.Equals("Minimum", StringComparison.OrdinalIgnoreCase);
+
+                return new Snapshot(bottleneck.cu, bottleneck.tg, achieved, single);
+            }
+            catch (OperationCanceledException) { return null; }
+            catch { return null; }
+        }
+
+        private sealed record Snapshot(long Current, long Target, bool Achieved, bool IsSingleShot);
+    }
+}

--- a/XAU/Services/AutoUnlock/EventUnlocker.cs
+++ b/XAU/Services/AutoUnlock/EventUnlocker.cs
@@ -1,0 +1,423 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using XAU.AutoUnlock;
+
+namespace XAU.Services.AutoUnlock
+{
+    public class EventUnlocker
+    {
+        private const int BatchSize = 500;
+        private const int MaxEvents = 10000;
+        private const int MaxRetries = 5;
+
+        private readonly XboxRestAPI _api;
+        private readonly string _titleId;
+        private readonly string _xuid;
+        private readonly string _eventsToken;
+
+        private static readonly Random _random = new Random();
+
+        public EventUnlocker(XboxRestAPI api, string titleId, string xuid, string eventsToken)
+        {
+            _api = api;
+            _titleId = titleId;
+            _xuid = xuid;
+            _eventsToken = eventsToken;
+        }
+
+        private static string EventsFolder =>
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU", "Events");
+
+        private string ReadTemplate()
+        {
+            var path = Path.Combine(EventsFolder, $"{_titleId}.json");
+            if (!File.Exists(path))
+                throw new FileNotFoundException($"Event template not found for title {_titleId}.");
+            return File.ReadAllText(path);
+        }
+
+        public async Task UnlockAsync(string achievementId, JObject gameData, int loopMultiplier = 1)
+        {
+            var template = ReadTemplate();
+            loopMultiplier = Math.Max(1, loopMultiplier);
+
+            var node = ResolveNode(gameData, achievementId, template);
+
+            if (node == null || (!CategoryDetector.HasRequests(node) && CollectReplacements(node).Count == 0))
+                throw new InvalidOperationException(
+                    $"Achievement {achievementId} is not in this game's Data.json and could not be inferred.");
+
+            if (CategoryDetector.HasRequests(node))
+            {
+                await SendWithRequestsAsync(template, node, loopMultiplier);
+            }
+            else
+            {
+                var count = GetLoop(node) * loopMultiplier;
+                var templateBody = BuildTemplateBody(template, CollectReplacements(node));
+                await SendManyAsync(templateBody, count);
+            }
+        }
+
+        private JObject? ResolveNode(JObject gameData, string achievementId, string template)
+        {
+            var node = gameData?["Achievements"]?[achievementId] as JObject;
+            bool hasData = node != null && (CategoryDetector.HasRequests(node) || CollectReplacements(node).Count > 0);
+            if (!hasData)
+            {
+                node = node ?? InferFromSiblings(gameData, achievementId, template);
+                node = AugmentWithDynamic(template, achievementId, node);
+            }
+            return node;
+        }
+
+        public async Task SendEventsAsync(string achievementId, JObject gameData, int count)
+        {
+            var template = ReadTemplate();
+            var node = ResolveNode(gameData, achievementId, template);
+            if (node == null || (!CategoryDetector.HasRequests(node) && CollectReplacements(node).Count == 0))
+                throw new InvalidOperationException($"Achievement {achievementId} has no event data to send.");
+
+            count = Math.Max(1, count);
+            if (CategoryDetector.HasRequests(node))
+            {
+                for (int i = 0; i < count; i++)
+                    await SendWithRequestsAsync(template, node, 1);
+            }
+            else
+            {
+                var body = BuildTemplateBody(template, CollectReplacements(node));
+                await SendManyAsync(body, count);
+            }
+        }
+
+        private async Task SendWithRequestsAsync(string template, JObject achievementData, int loopMultiplier)
+        {
+            var generalReplacements = new List<JObject>();
+            var requests = new List<(int order, JObject node)>();
+
+            foreach (var prop in achievementData.Properties())
+            {
+                if (prop.Name.StartsWith("Request", StringComparison.OrdinalIgnoreCase) && prop.Value is JObject reqObj)
+                {
+                    var suffix = prop.Name.Substring("Request".Length);
+                    int.TryParse(suffix, out var n);
+                    requests.Add((n, reqObj));
+                }
+                else if (prop.Value is JObject obj && obj["ReplacementType"] != null)
+                {
+                    generalReplacements.Add(obj);
+                }
+            }
+
+            foreach (var (_, reqObj) in requests.OrderBy(r => r.order))
+            {
+                var all = new List<JObject>();
+                all.AddRange(CollectReplacements(reqObj));
+                all.AddRange(generalReplacements);
+
+                var count = GetLoop(reqObj) * loopMultiplier;
+                var templateBody = BuildTemplateBody(template, all);
+                await SendManyAsync(templateBody, count);
+            }
+        }
+
+        private static int GetLoop(JObject node)
+        {
+            var token = node["Loop"] ?? node["loop"];
+            if (token == null)
+                return 1;
+            if (token.Type == JTokenType.Integer)
+                return Math.Max(1, token.Value<int>());
+            if (int.TryParse(token.ToString(), out var n))
+                return Math.Max(1, n);
+            return 1;
+        }
+
+        private static List<JObject> CollectReplacements(JObject node)
+        {
+            var list = new List<JObject>();
+            foreach (var prop in node.Properties())
+            {
+                if (prop.Value is JObject obj && obj["ReplacementType"] != null)
+                    list.Add(obj);
+            }
+            return list;
+        }
+
+        private string BuildTemplateBody(string template, List<JObject> replacements)
+        {
+            var body = template;
+            foreach (var repl in replacements)
+                body = ApplyOne(body, repl);
+            body = body.Replace("REPLACEXUID", _xuid);
+            return body;
+        }
+
+        private static string FinalizeEvent(string templateBody, long seq)
+        {
+            var now = DateTime.UtcNow;
+            var body = templateBody
+                .Replace("REPLACETIME", now.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+                .Replace("REPLACESEQ", seq.ToString());
+            return JObject.Parse(body).ToString(Formatting.None);
+        }
+
+        private async Task SendManyAsync(string templateBody, int count)
+        {
+            count = Math.Clamp(count, 1, MaxEvents);
+            var baseSeq = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            await SendBatchAsync(new List<string> { FinalizeEvent(templateBody, baseSeq) });
+            if (count == 1)
+                return;
+
+            var batch = new List<string>(BatchSize);
+            for (int i = 1; i < count; i++)
+            {
+                batch.Add(FinalizeEvent(templateBody, baseSeq + i));
+                if (batch.Count >= BatchSize)
+                {
+                    await SendBatchAsync(batch);
+                    batch.Clear();
+                }
+            }
+            if (batch.Count > 0)
+                await SendBatchAsync(batch);
+        }
+
+        private async Task SendBatchAsync(List<string> events)
+        {
+            var ndjson = string.Join("\n", events);
+
+            for (int attempt = 0; attempt < MaxRetries; attempt++)
+            {
+                int status = await _api.SendEventBatchAsync(_eventsToken, ndjson);
+
+                if (status >= 200 && status < 300)
+                    return;
+
+                if (status == 401 || status == 403)
+                    throw new Exception("Event token expired or invalid. Please refresh your event token.");
+
+                // 429 (rate limit) é transitório: espera e tenta de novo.
+                bool transient = status == 0 || status == 429 || status >= 500;
+                if (transient && attempt < MaxRetries - 1)
+                {
+                    await Task.Delay(1000 * (int)Math.Pow(2, attempt));
+                    continue;
+                }
+
+                throw new Exception($"OneCollector returned HTTP {status}.");
+            }
+        }
+
+
+        private static readonly Regex PlaceholderRegex = new Regex("REPLACE[A-Z0-9]+", RegexOptions.Compiled);
+
+        private static (List<string> ev, List<string> meta, List<string> data, List<string> name, List<string> id)
+            DetectPlaceholders(string template)
+        {
+            var found = PlaceholderRegex.Matches(template)
+                .Select(m => m.Value)
+                .Distinct()
+                .Where(p => p != "REPLACETIME" && p != "REPLACESEQ" && p != "REPLACEXUID")
+                .ToList();
+            var ev = found.Where(p => p.Contains("EVENT") || p == "REPLACETITLE").ToList();
+            var meta = found.Where(p => p.Contains("METADATA")).ToList();
+            var data = found.Where(p => p.Contains("DATA") && !p.Contains("METADATA")).ToList();
+            var name = found.Where(p => p == "REPLACENAME").ToList();
+            var id = found.Where(p =>
+                p == "REPLACEID" || p == "REPLACEINDEX" || p.Contains("CRITERIA")
+                || p == "REPLACECCRITERADDEPC" || p == "REPLACESTATVALUE").ToList();
+            return (ev, meta, data, name, id);
+        }
+
+        private JObject AugmentWithDynamic(string template, string achievementId, JObject? node)
+        {
+            var result = node != null ? (JObject)node.DeepClone() : new JObject();
+
+            var covered = new HashSet<string>();
+            foreach (var r in CollectReplacements(result))
+            {
+                var t = r["Target"]?.ToString();
+                if (!string.IsNullOrEmpty(t))
+                    covered.Add(t);
+            }
+
+            var internalId = ExtractInternalId(result, achievementId);
+            var (ev, meta, data, name, id) = DetectPlaceholders(template);
+
+            void Add(string placeholder, string replacement)
+            {
+                if (covered.Contains(placeholder))
+                    return;
+                covered.Add(placeholder);
+                result[$"{placeholder}Replacement"] = new JObject
+                {
+                    ["ReplacementType"] = "Replace",
+                    ["Target"] = placeholder,
+                    ["Replacement"] = replacement
+                };
+            }
+
+            foreach (var p in ev)
+                Add(p, $"Microsoft.XboxLive.T{_titleId}.UnlockAchievement");
+            foreach (var p in data)
+                Add(p, $"{{\"baseType\":\"Microsoft.XboxLive.InGame\",\"baseData\":{{\"name\":\"UnlockAchievement\",\"serviceConfigId\":\"b4900100-fd0c-476f-b32e-b74a4ae8f9b2\",\"playerSessionId\":\"11111111-1111-1111-1111-111111111111\",\"titleId\":\"{_titleId}\",\"userId\":\"REPLACEXUID\",\"ver\":1,\"properties\":{{\"UnlockId\":{internalId}}},\"measurements\":{{\"ProgressPercent\":100}}}}}}");
+            foreach (var p in meta)
+                Add(p, $"{{\"properties\":{{\"f\":{{\"AchievementID\":{internalId}}}}},\"measurements\":{{\"f\":{{\"ProgressPercent\":100}}}}}}");
+            foreach (var p in name)
+                Add(p, achievementId);
+            foreach (var p in id)
+                Add(p, internalId);
+
+            return result;
+        }
+
+        private static string ExtractInternalId(JObject? node, string xboxId)
+        {
+            if (node != null)
+            {
+                var repl = node["DataReplacement"]?["Replacement"];
+                string? replStr = null;
+                if (repl != null && repl.Type == JTokenType.String) replStr = repl.ToString();
+                else if (repl != null && repl.Type == JTokenType.Integer) replStr = repl.ToString();
+
+                if (replStr != null)
+                {
+                    if (replStr.Length > 0 && replStr.All(char.IsDigit))
+                        return replStr;
+                    var m = Regex.Match(replStr, "\"AchievementID\"\\s*:\\s*(\\d+)");
+                    if (m.Success)
+                        return m.Groups[1].Value;
+                }
+
+                if (node["Replacement"] is JObject ro && ro["Replacement"] is JToken rv)
+                {
+                    if (rv.Type == JTokenType.Integer) return rv.ToString();
+                    if (rv.Type == JTokenType.String && rv.ToString().All(char.IsDigit)) return rv.ToString();
+                }
+            }
+            return xboxId;
+        }
+
+        private JObject? InferFromSiblings(JObject? gameData, string achievementId, string template)
+        {
+            var achievements = gameData?["Achievements"] as JObject;
+            if (achievements == null)
+                return null;
+
+            var (ev, meta, data, _, _) = DetectPlaceholders(template);
+
+            foreach (var prop in achievements.Properties())
+            {
+                if (prop.Name == achievementId || prop.Value is not JObject other)
+                    continue;
+
+                bool hasNeeded =
+                    (ev.Count > 0 && other["EventReplacement"] != null)
+                    || (meta.Count > 0 && other["MetaDataReplacement"] != null)
+                    || (data.Count > 0 && other["DataReplacement"] != null)
+                    || CategoryDetector.HasRequests(other)
+                    || CollectReplacements(other).Count > 0;
+                if (!hasNeeded)
+                    continue;
+
+                var clone = (JObject)other.DeepClone();
+                RewriteIds(clone, prop.Name, achievementId);
+                return clone;
+            }
+            return null;
+        }
+
+        private static void RewriteIds(JObject node, string fromId, string toId)
+        {
+            foreach (var prop in node.Properties().ToList())
+            {
+                if (prop.Value is JObject obj && obj["ReplacementType"] != null)
+                {
+                    var repl = obj["Replacement"];
+                    if (repl != null && repl.Type == JTokenType.String)
+                    {
+                        var s = repl.ToString().Replace(fromId, toId);
+                        s = Regex.Replace(s, "\"UnlockId\"\\s*:\\s*\\d+", $"\"UnlockId\":{toId}");
+                        s = Regex.Replace(s, "\"AchievementID\"\\s*:\\s*\\d+", $"\"AchievementID\":{toId}");
+                        obj["Replacement"] = s;
+                    }
+                    else if (repl != null && repl.Type == JTokenType.Integer)
+                    {
+                        if (long.TryParse(toId, out var n)) obj["Replacement"] = n;
+                        else obj["Replacement"] = toId;
+                    }
+                }
+                else if (prop.Name.StartsWith("Request", StringComparison.OrdinalIgnoreCase) && prop.Value is JObject reqObj)
+                {
+                    RewriteIds(reqObj, fromId, toId);
+                }
+            }
+        }
+
+        private string ApplyOne(string body, JObject repl)
+        {
+            var type = repl["ReplacementType"]?.ToString() ?? "Replace";
+            var target = repl["Target"]?.ToString() ?? "";
+            if (string.IsNullOrEmpty(target))
+                return body;
+
+            switch (type)
+            {
+                case "Replace":
+                {
+                    var value = ValueAsText(repl["Replacement"]);
+                    value = value.Replace("REPLACEXUID", _xuid);
+                    return body.Replace(target, value);
+                }
+                case "RangeInt":
+                {
+                    var min = (int)ReadNumber(repl["Min"], 0);
+                    var max = (int)ReadNumber(repl["Max"], 100);
+                    if (max < min) (min, max) = (max, min);
+                    var picked = _random.Next(min, max + 1);
+                    return body.Replace(target, picked.ToString());
+                }
+                case "RangeFloat":
+                {
+                    var min = ReadNumber(repl["Min"], 0);
+                    var max = ReadNumber(repl["Max"], 1);
+                    if (max < min) (min, max) = (max, min);
+                    var picked = min + _random.NextDouble() * (max - min);
+                    return body.Replace(target, picked.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                }
+                case "StupidFuckingLDAPTimestamp":
+                {
+                    var ldap = DateTime.Now.ToFileTime();
+                    return body.Replace(target, ldap.ToString());
+                }
+                default:
+                    return body;
+            }
+        }
+
+        private static string ValueAsText(JToken? token)
+        {
+            if (token == null) return "";
+            return token.Type == JTokenType.String ? token.ToString() : token.ToString(Formatting.None).Trim('"');
+        }
+
+        private static double ReadNumber(JToken? token, double fallback)
+        {
+            if (token == null) return fallback;
+            if (token.Type == JTokenType.Integer || token.Type == JTokenType.Float)
+                return token.Value<double>();
+            return double.TryParse(token.ToString(), System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out var n) ? n : fallback;
+        }
+    }
+}

--- a/XAU/Services/AutoUnlock/OrderRepository.cs
+++ b/XAU/Services/AutoUnlock/OrderRepository.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using XAU.AutoUnlock;
+
+namespace XAU.Services.AutoUnlock
+{
+    public static class OrderRepository
+    {
+        private const long MaxGapSeconds = 5 * 60 * 60;
+        private const long RandomMinSeconds = 20 * 60;
+        private const long RandomMaxSeconds = 90 * 60;
+
+        private static readonly Random _random = new Random();
+
+        private static string BaseFolder =>
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU", "UnlockOrders");
+
+        private static string StateFolder => Path.Combine(BaseFolder, "State");
+        private static string SkipFolder => Path.Combine(BaseFolder, "Skip");
+
+        private static string OrderPath(string titleId) => Path.Combine(BaseFolder, $"{titleId}.json");
+        private static string StatePath(string titleId) => Path.Combine(StateFolder, $"{titleId}.json");
+        private static string SkipPath(string titleId) => Path.Combine(SkipFolder, $"{titleId}.json");
+
+        public static bool Exists(string titleId) => File.Exists(OrderPath(titleId));
+
+        public static UnlockOrder? Load(string titleId)
+        {
+            var path = OrderPath(titleId);
+            if (!File.Exists(path))
+                return null;
+            try
+            {
+                return JsonConvert.DeserializeObject<UnlockOrder>(File.ReadAllText(path));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static void Save(UnlockOrder order)
+        {
+            Directory.CreateDirectory(BaseFolder);
+            var json = JsonConvert.SerializeObject(order, Formatting.Indented);
+            WriteAtomic(OrderPath(order.TitleId), json);
+        }
+
+        public static void Delete(string titleId)
+        {
+            var path = OrderPath(titleId);
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+
+        public static AutoUnlockState? LoadState(string titleId)
+        {
+            var path = StatePath(titleId);
+            if (!File.Exists(path))
+                return null;
+            try
+            {
+                return JsonConvert.DeserializeObject<AutoUnlockState>(File.ReadAllText(path));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static void SaveState(AutoUnlockState state)
+        {
+            Directory.CreateDirectory(StateFolder);
+            var json = JsonConvert.SerializeObject(state, Formatting.Indented);
+            WriteAtomic(StatePath(state.TitleId), json);
+        }
+
+        private static void WriteAtomic(string path, string content)
+        {
+            var temp = path + ".tmp";
+            File.WriteAllText(temp, content);
+            if (File.Exists(path))
+                File.Replace(temp, path, null);
+            else
+                File.Move(temp, path);
+        }
+
+        public static void ClearState(string titleId)
+        {
+            var path = StatePath(titleId);
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+
+        public static HashSet<string> LoadSkip(string titleId)
+        {
+            var path = SkipPath(titleId);
+            if (!File.Exists(path))
+                return new HashSet<string>();
+            try
+            {
+                var list = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(path));
+                return list == null ? new HashSet<string>() : new HashSet<string>(list);
+            }
+            catch
+            {
+                return new HashSet<string>();
+            }
+        }
+
+        public static void SaveSkip(string titleId, HashSet<string> ids)
+        {
+            Directory.CreateDirectory(SkipFolder);
+            var json = JsonConvert.SerializeObject(ids.ToList(), Formatting.Indented);
+            WriteAtomic(SkipPath(titleId), json);
+        }
+
+        public static async Task<UnlockOrder> GenerateFromReferenceAsync(
+            XboxRestAPI api,
+            string titleId,
+            string gameName,
+            string gamertag,
+            HashSet<string> userOwnedIds)
+        {
+            JObject? profile;
+            try
+            {
+                profile = await api.GetGamertagProfileAsync(gamertag);
+            }
+            catch
+            {
+                throw new Exception($"We couldn't find the gamertag \"{gamertag}\". Check the spelling and try again.");
+            }
+
+            var referenceXuid = profile?["profileUsers"]?.FirstOrDefault()?["id"]?.ToString();
+            if (string.IsNullOrWhiteSpace(referenceXuid))
+                throw new Exception($"Could not resolve the gamertag \"{gamertag}\".");
+
+            var response = await api.GetAchievementsForTitleAsync(referenceXuid, titleId);
+            if (response?.achievements == null || response.achievements.Count == 0)
+                throw new Exception($"\"{gamertag}\" has no visible achievements in this game (profile may be private).");
+
+            var skip = LoadSkip(titleId);
+            var earned = new List<(string id, string name, DateTime when, int gs)>();
+            foreach (var ach in response.achievements)
+            {
+                if (ach.progressState != StringConstants.Achieved)
+                    continue;
+                if (userOwnedIds.Contains(ach.id))
+                    continue;
+                if (skip.Contains(ach.id))
+                    continue;
+
+                var when = ParseDate(ach.progression?.timeUnlocked);
+                if (when == null)
+                    continue;
+
+                earned.Add((ach.id, ach.name, when.Value, ExtractGamerscore(ach)));
+            }
+
+            if (earned.Count == 0)
+                throw new Exception("Nothing left to unlock -- you already have everything this reference has.");
+
+            earned.Sort((a, b) => a.when.CompareTo(b.when));
+
+            var items = new List<UnlockOrderItem>();
+            DateTime? previous = null;
+            foreach (var c in earned)
+            {
+                long delay;
+                if (previous == null)
+                {
+                    delay = 0;
+                }
+                else
+                {
+                    var gap = (long)Math.Round((c.when - previous.Value).TotalSeconds);
+                    if (gap > MaxGapSeconds)
+                        delay = RandomMinSeconds + (long)(_random.NextDouble() * (RandomMaxSeconds - RandomMinSeconds));
+                    else
+                        delay = Math.Max(1, gap);
+                }
+
+                items.Add(new UnlockOrderItem
+                {
+                    Id = c.id,
+                    Name = c.name,
+                    DelaySeconds = delay,
+                    Gamerscore = c.gs
+                });
+
+                previous = c.when;
+            }
+
+            return new UnlockOrder
+            {
+                TitleId = titleId,
+                GameName = gameName,
+                ReferenceGamertag = gamertag,
+                GeneratedAt = DateTime.UtcNow,
+                Items = items
+            };
+        }
+
+        private static DateTime? ParseDate(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text) || text.StartsWith("0001-01-01"))
+                return null;
+            if (DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dto))
+            {
+                var utc = dto.UtcDateTime;
+                if (utc.Year < 2005)
+                    return null;
+                return utc;
+            }
+            return null;
+        }
+
+        private static int ExtractGamerscore(OneCoreAchievementResponse ach)
+        {
+            var reward = ach.rewards?.FirstOrDefault(r => r.type == StringConstants.Gamerscore);
+            if (reward != null && int.TryParse(reward.value, out var value))
+                return value;
+            return 0;
+        }
+    }
+}

--- a/XAU/Services/AutoUnlock/RtaAchievementStream.cs
+++ b/XAU/Services/AutoUnlock/RtaAchievementStream.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace XAU.Services.AutoUnlock
+{
+    public interface IChangeSignal
+    {
+        bool IsAlive { get; }
+        Task<bool> WaitAsync(TimeSpan timeout, CancellationToken token);
+    }
+
+    public sealed class RtaAchievementStream : IChangeSignal, IDisposable
+    {
+        private const string NonceUrl = "https://rta.xboxlive.com/nonce";
+        private const string WsBase = "wss://rta.xboxlive.com/connect";
+        private const string SubProtocol = "rta.xboxlive.com.V2";
+
+        private readonly ClientWebSocket _ws;
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private volatile bool _alive;
+        private TaskCompletionSource<bool> _changed =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool IsAlive => _alive && !_cts.IsCancellationRequested;
+
+        private RtaAchievementStream(ClientWebSocket ws)
+        {
+            _ws = ws;
+        }
+
+        public static async Task<RtaAchievementStream?> TryStartAsync(
+            string xauthToken, string xuid, string scid, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(xauthToken) || string.IsNullOrEmpty(xuid) || string.IsNullOrEmpty(scid))
+                return null;
+
+            ClientWebSocket? ws = null;
+            try
+            {
+                string nonce;
+                using (var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+                using (var req = new HttpRequestMessage(HttpMethod.Get, NonceUrl))
+                {
+                    req.Headers.TryAddWithoutValidation("Authorization", xauthToken);
+                    req.Headers.TryAddWithoutValidation("Accept", "application/json");
+                    using var resp = await http.SendAsync(req, token);
+                    if (!resp.IsSuccessStatusCode)
+                        return null;
+                    var body = await resp.Content.ReadAsStringAsync();
+                    nonce = JObject.Parse(body)["nonce"]?.ToString() ?? "";
+                    if (string.IsNullOrEmpty(nonce))
+                        return null;
+                }
+
+                ws = new ClientWebSocket();
+                ws.Options.AddSubProtocol(SubProtocol);
+                ws.Options.SetRequestHeader("User-Agent", "XboxServicesAPI/2021.10.20211005.0 c");
+                var url = $"{WsBase}?nonce={Uri.EscapeDataString(nonce)}";
+                using (var connectCts = CancellationTokenSource.CreateLinkedTokenSource(token))
+                {
+                    connectCts.CancelAfter(TimeSpan.FromSeconds(10));
+                    await ws.ConnectAsync(new Uri(url), connectCts.Token);
+                }
+
+                var uri = $"https://achievements.xboxlive.com/users/xuid({xuid})/achievements/{scid.ToLowerInvariant()}";
+                var subscribe = $"[1,1,{JsonConvert.SerializeObject(uri)}]";
+                var bytes = Encoding.UTF8.GetBytes(subscribe);
+                await ws.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, token);
+
+                var stream = new RtaAchievementStream(ws) { _alive = true };
+                _ = Task.Run(() => stream.PumpAsync());
+                return stream;
+            }
+            catch
+            {
+                try { ws?.Dispose(); } catch { }
+                return null;
+            }
+        }
+
+        public async Task<bool> WaitAsync(TimeSpan timeout, CancellationToken token)
+        {
+            var tcs = _changed;
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var delay = Task.Delay(timeout, linked.Token);
+            var done = await Task.WhenAny(tcs.Task, delay);
+            if (done == tcs.Task)
+            {
+                linked.Cancel();
+                return true;
+            }
+            return false;
+        }
+
+        private void Pulse()
+        {
+            var fresh = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var old = Interlocked.Exchange(ref _changed, fresh);
+            old.TrySetResult(true);
+        }
+
+        private async Task PumpAsync()
+        {
+            var buffer = new byte[8192];
+            var sb = new StringBuilder();
+            int subId = -1;
+            try
+            {
+                while (!_cts.IsCancellationRequested && _ws.State == WebSocketState.Open)
+                {
+                    sb.Clear();
+                    WebSocketReceiveResult result;
+                    do
+                    {
+                        result = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), _cts.Token);
+                        if (result.MessageType == WebSocketMessageType.Close)
+                            return;
+                        sb.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+                    } while (!result.EndOfMessage);
+
+                    JArray arr;
+                    try { arr = JArray.Parse(sb.ToString()); }
+                    catch { continue; }
+                    if (arr.Count == 0)
+                        continue;
+
+                    var type = arr[0].Value<int?>() ?? 0;
+                    if (type == 1 && arr.Count == 5)
+                    {
+                        var status = arr[2].Value<int?>() ?? -1;
+                        if (status == 0)
+                            subId = arr[3].Value<int?>() ?? -1;
+                        else
+                            return; // rejeitado (throttle/limite/recurso desconhecido)
+                    }
+                    else if (type == 3 && arr.Count >= 2)
+                    {
+                        var evtSub = arr[1].Value<int?>() ?? -1;
+                        if (subId < 0 || evtSub == subId)
+                            Pulse();
+                    }
+                    else if (type == 4)
+                    {
+                        Pulse();
+                    }
+                }
+            }
+            catch
+            {
+            }
+            finally
+            {
+                _alive = false;
+                Pulse();
+            }
+        }
+
+        public void Dispose()
+        {
+            _alive = false;
+            try { _cts.Cancel(); } catch { }
+            try
+            {
+                if (_ws.State == WebSocketState.Open)
+                    _ = _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+            }
+            catch { }
+            try { _ws.Dispose(); } catch { }
+            try { _cts.Dispose(); } catch { }
+            Pulse();
+        }
+    }
+}

--- a/XAU/Services/AutoUnlock/UnlockVerifier.cs
+++ b/XAU/Services/AutoUnlock/UnlockVerifier.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace XAU.Services.AutoUnlock
+{
+    public enum VerifyOutcome
+    {
+        Confirmed,
+        Pending,
+        Cancelled
+    }
+
+    public sealed class UnlockVerifier
+    {
+        private readonly XboxRestAPI _api;
+        private readonly string _xuid;
+        private readonly string _titleId;
+        private static readonly Random _jitter = new Random();
+
+        public UnlockVerifier(XboxRestAPI api, string xuid, string titleId)
+        {
+            _api = api;
+            _xuid = xuid;
+            _titleId = titleId;
+        }
+
+        public async Task<VerifyOutcome> WaitForAchievedAsync(string achievementId, bool eventBased, CancellationToken token, IChangeSignal? signal = null)
+        {
+            var timeout = eventBased ? TimeSpan.FromMinutes(3) : TimeSpan.FromSeconds(30);
+            var deadline = DateTime.UtcNow + timeout;
+            // Rápido no começo (pega unlock instantâneo), depois estabiliza sem inflar.
+            int[] backoff = { 3, 6, 10, 10, 15, 15 };
+            int attempt = 0;
+
+            while (true)
+            {
+                if (token.IsCancellationRequested)
+                    return VerifyOutcome.Cancelled;
+
+                try
+                {
+                    await XboxRateLimiter.Achievements.WaitAsync(token);
+                    var resp = await _api.GetAchievementsForTitleAsync(_xuid, _titleId);
+                    var ach = resp?.achievements?.FirstOrDefault(a => a.id == achievementId);
+                    if (ach != null && ach.progressState == StringConstants.Achieved)
+                        return VerifyOutcome.Confirmed;
+                }
+                catch (OperationCanceledException)
+                {
+                    return VerifyOutcome.Cancelled;
+                }
+                catch
+                {
+                }
+
+                if (DateTime.UtcNow >= deadline)
+                    return VerifyOutcome.Pending;
+
+                var baseSec = backoff[Math.Min(attempt, backoff.Length - 1)];
+                attempt++;
+                var seconds = baseSec * (0.8 + _jitter.NextDouble() * 0.4);
+                var wait = TimeSpan.FromSeconds(seconds);
+                var remaining = deadline - DateTime.UtcNow;
+                if (wait > remaining)
+                    wait = remaining;
+                if (wait <= TimeSpan.Zero)
+                    return VerifyOutcome.Pending;
+
+                try
+                {
+                    if (signal != null && signal.IsAlive)
+                        await signal.WaitAsync(wait, token);
+                    else
+                        await Task.Delay(wait, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return VerifyOutcome.Cancelled;
+                }
+            }
+        }
+    }
+}

--- a/XAU/Services/AutoUnlock/XboxRateLimiter.cs
+++ b/XAU/Services/AutoUnlock/XboxRateLimiter.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace XAU.Services.AutoUnlock
+{
+    public sealed class XboxRateLimiter
+    {
+        public static readonly XboxRateLimiter Achievements = new XboxRateLimiter(90, 280);
+        public static readonly XboxRateLimiter StatsRead = new XboxRateLimiter(90, 280);
+        public static readonly XboxRateLimiter StatsWrite = new XboxRateLimiter(90, 280);
+
+        private static readonly TimeSpan BurstWindow = TimeSpan.FromSeconds(15);
+        private static readonly TimeSpan SustainWindow = TimeSpan.FromSeconds(300);
+
+        private readonly int _burstMax;
+        private readonly int _sustainMax;
+        private readonly Queue<DateTime> _burst = new Queue<DateTime>();
+        private readonly Queue<DateTime> _sustain = new Queue<DateTime>();
+        private readonly SemaphoreSlim _gate = new SemaphoreSlim(1, 1);
+
+        public XboxRateLimiter(int burstMax, int sustainMax)
+        {
+            _burstMax = burstMax;
+            _sustainMax = sustainMax;
+        }
+
+        public async Task WaitAsync(CancellationToken token)
+        {
+            await _gate.WaitAsync(token);
+            try
+            {
+                while (true)
+                {
+                    var now = DateTime.UtcNow;
+                    Trim(_burst, now - BurstWindow);
+                    Trim(_sustain, now - SustainWindow);
+
+                    if (_burst.Count < _burstMax && _sustain.Count < _sustainMax)
+                    {
+                        _burst.Enqueue(now);
+                        _sustain.Enqueue(now);
+                        return;
+                    }
+
+                    var waitBurst = _burst.Count >= _burstMax
+                        ? _burst.Peek() + BurstWindow - now
+                        : TimeSpan.Zero;
+                    var waitSustain = _sustain.Count >= _sustainMax
+                        ? _sustain.Peek() + SustainWindow - now
+                        : TimeSpan.Zero;
+                    var wait = waitBurst > waitSustain ? waitBurst : waitSustain;
+                    if (wait < TimeSpan.FromMilliseconds(50))
+                        wait = TimeSpan.FromMilliseconds(50);
+
+                    await Task.Delay(wait, token);
+                }
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private static void Trim(Queue<DateTime> q, DateTime cutoff)
+        {
+            while (q.Count > 0 && q.Peek() < cutoff)
+                q.Dequeue();
+        }
+    }
+}

--- a/XAU/Services/GdkTokenService.cs
+++ b/XAU/Services/GdkTokenService.cs
@@ -1,0 +1,176 @@
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+namespace XAU.Services;
+
+// Le o cache de tokens do Xbox-app (GDK / GamingServices) do disco. Os arquivos em
+// LocalState\Auth sao protegidos via DPAPI-NG para o usuario, entao um processo normal
+// decifra com NCryptUnprotectSecret (sem memory scan, sem injecao). O token de
+// RP=http://xboxlive.com tem capacidade de presenca, que tokens self-minted nao tem.
+public static class GdkTokenService
+{
+    [DllImport("ncrypt.dll")]
+    private static extern int NCryptUnprotectSecret(out IntPtr hDescriptor, uint flags, byte[] blob, uint cb,
+        IntPtr memPara, IntPtr hWnd, out IntPtr data, out uint len);
+
+    private const uint NCRYPT_SILENT_FLAG = 0x40;
+
+    private static byte[]? Unprotect(byte[] blob)
+    {
+        if (NCryptUnprotectSecret(out _, NCRYPT_SILENT_FLAG, blob, (uint)blob.Length, IntPtr.Zero, IntPtr.Zero, out var data, out var len) != 0)
+            return null;
+        var o = new byte[len];
+        Marshal.Copy(data, o, 0, (int)len);
+        return o;
+    }
+
+    public sealed record XToken(string Xbl, string Xuid, string Uhs, string Gamertag, DateTime NotAfter);
+    public sealed record UserToken(string Token, DateTime NotAfter);
+
+    // User token enrolled mais recente (RP auth.xboxlive.com). Vive ~dias — usado para
+    // re-gerar XSTS (fallback de xauth + events token) sem o app.
+    public static UserToken? GetUserToken()
+    {
+        if (!Directory.Exists(AuthDir)) return null;
+        UserToken? best = null;
+        foreach (var file in Directory.EnumerateFiles(AuthDir, "*", SearchOption.AllDirectories))
+        {
+            byte[]? dec;
+            try { dec = Unprotect(File.ReadAllBytes(file)); }
+            catch { continue; }
+            if (dec == null) continue;
+            try
+            {
+                var root = JsonDocument.Parse(Encoding.UTF8.GetString(dec)).RootElement;
+                if (!root.TryGetProperty("IdentityType", out var it) || it.GetString() != "Utoken") continue;
+                var td = root.GetProperty("TokenData");
+                var token = td.GetProperty("Token").GetString();
+                var notAfter = td.TryGetProperty("NotAfter", out var na) && na.TryGetDateTime(out var dt) ? dt.ToUniversalTime() : DateTime.MinValue;
+                if (notAfter < DateTime.UtcNow || string.IsNullOrEmpty(token)) continue;
+                if (best == null || notAfter > best.NotAfter) best = new UserToken(token, notAfter);
+            }
+            catch { }
+        }
+        return best;
+    }
+
+    private static string AuthDir => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Packages", "Microsoft.GamingServices_8wekyb3d8bbwe", "LocalState", "Auth");
+
+    public static bool CacheExists => Directory.Exists(AuthDir);
+
+    private static readonly HttpClient Http = new();
+
+    // Events token de uma conta, gerado do user token em cache (Utoken). O Utoken nao
+    // tem xid, entao cada candidato e identificado gerando um XSTS xboxlive.com e
+    // casando o xid com o alvo; depois gera o XSTS events.xboxlive.com do mesmo token.
+    public static async Task<string?> MintEventsTokenAsync(string xuid, string uhs)
+    {
+        foreach (var ut in GetValidUserTokens())
+        {
+            try
+            {
+                var (c1, b1) = await PostXstsAsync(ut, "http://xboxlive.com");
+                if (c1 != 200) continue;
+                var xui = JsonDocument.Parse(b1).RootElement.GetProperty("DisplayClaims").GetProperty("xui")[0];
+                var xid = xui.TryGetProperty("xid", out var x) ? x.GetString() : null;
+                if (xid != xuid) continue;
+
+                var (c2, b2) = await PostXstsAsync(ut, "http://events.xboxlive.com");
+                if (c2 != 200) return null;
+                var tok = JsonDocument.Parse(b2).RootElement.GetProperty("Token").GetString();
+                return string.IsNullOrEmpty(tok) ? null : $"x:XBL3.0 x={uhs};{tok}";
+            }
+            catch { }
+        }
+        return null;
+    }
+
+    private static async Task<(int code, string body)> PostXstsAsync(string userToken, string rp)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            Properties = new { SandboxId = "RETAIL", UserTokens = new[] { userToken } },
+            RelyingParty = rp,
+            TokenType = "JWT"
+        });
+        using var resp = await Http.PostAsync("https://xsts.auth.xboxlive.com/xsts/authorize",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+        return ((int)resp.StatusCode, await resp.Content.ReadAsStringAsync());
+    }
+
+    // Todos os user tokens validos em cache (Utoken, RP auth.xboxlive.com), um por conta.
+    private static List<string> GetValidUserTokens()
+    {
+        var list = new List<string>();
+        if (!Directory.Exists(AuthDir)) return list;
+        foreach (var file in Directory.EnumerateFiles(AuthDir, "*", SearchOption.AllDirectories))
+        {
+            byte[]? dec;
+            try { dec = Unprotect(File.ReadAllBytes(file)); }
+            catch { continue; }
+            if (dec == null) continue;
+            try
+            {
+                var root = JsonDocument.Parse(Encoding.UTF8.GetString(dec)).RootElement;
+                if (!root.TryGetProperty("IdentityType", out var it) || it.GetString() != "Utoken") continue;
+                if (!root.TryGetProperty("RelyingParty", out var rp) || rp.GetString() != "http://auth.xboxlive.com") continue;
+                var td = root.GetProperty("TokenData");
+                var notAfter = td.TryGetProperty("NotAfter", out var na) && na.TryGetDateTime(out var dt) ? dt.ToUniversalTime() : DateTime.MinValue;
+                if (notAfter < DateTime.UtcNow) continue;
+                var tok = td.GetProperty("Token").GetString();
+                if (!string.IsNullOrEmpty(tok)) list.Add(tok!);
+            }
+            catch { }
+        }
+        return list;
+    }
+
+    // Todos os XSTS validos (RP xboxlive.com) em cache do Xbox app, mais recentes primeiro.
+    // Um por conta logada.
+    public static List<XToken> GetXboxLiveTokens()
+    {
+        var result = new List<XToken>();
+        if (!Directory.Exists(AuthDir)) return result;
+
+        foreach (var file in Directory.EnumerateFiles(AuthDir, "*", SearchOption.AllDirectories))
+        {
+            byte[]? dec;
+            try { dec = Unprotect(File.ReadAllBytes(file)); }
+            catch { continue; }
+            if (dec == null) continue;
+
+            try
+            {
+                var root = JsonDocument.Parse(Encoding.UTF8.GetString(dec)).RootElement;
+                if (!root.TryGetProperty("IdentityType", out var it) || it.GetString() != "Xtoken") continue;
+                if (!root.TryGetProperty("RelyingParty", out var rpEl) || rpEl.GetString() != "http://xboxlive.com") continue;
+                if (!root.TryGetProperty("TokenData", out var td)) continue;
+
+                var token = td.GetProperty("Token").GetString();
+                var notAfter = td.TryGetProperty("NotAfter", out var na) && na.TryGetDateTime(out var dt) ? dt.ToUniversalTime() : DateTime.MinValue;
+                if (notAfter < DateTime.UtcNow) continue;
+
+                var xui = td.GetProperty("DisplayClaims").GetProperty("xui")[0];
+                var uhs = xui.TryGetProperty("uhs", out var u) ? u.GetString() ?? "" : "";
+                var xid = xui.TryGetProperty("xid", out var x) ? x.GetString() ?? "0" : "0";
+                var gtg = xui.TryGetProperty("gtg", out var g) ? g.GetString() ?? "" : "";
+                if (xid == "0" || string.IsNullOrEmpty(token) || string.IsNullOrEmpty(uhs)) continue;
+
+                result.Add(new XToken($"XBL3.0 x={uhs};{token}", xid, uhs, gtg, notAfter));
+            }
+            catch { }
+        }
+
+        // Distinto por xuid, token mais recente por conta.
+        return result
+            .GroupBy(t => t.Xuid)
+            .Select(grp => grp.OrderByDescending(t => t.NotAfter).First())
+            .OrderByDescending(t => t.NotAfter)
+            .ToList();
+    }
+}

--- a/XAU/Services/OAuthLoginWindow.cs
+++ b/XAU/Services/OAuthLoginWindow.cs
@@ -1,0 +1,82 @@
+using System.IO;
+using System.Windows;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace XAU.Services;
+
+// Login Microsoft interativo minimo. Mostra a pagina OAuth do login.live.com num
+// WebView2 e resolve com o `code` quando redireciona para oauth20_desktop.
+public class OAuthLoginWindow : Window
+{
+    private readonly WebView2 _web = new();
+    private readonly TaskCompletionSource<string?> _tcs = new();
+    private readonly string _authUrl;
+    private readonly string _redirectUrl;
+    private bool _done;
+
+    public OAuthLoginWindow(string authUrl, string redirectUrl)
+    {
+        _authUrl = authUrl;
+        _redirectUrl = redirectUrl;
+        Title = "Sign in to Microsoft / Xbox";
+        Width = 480;
+        Height = 660;
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        Content = _web;
+        Loaded += OnLoaded;
+        Closed += (_, _) => _tcs.TrySetResult(null);
+    }
+
+    public Task<string?> GetCodeAsync()
+    {
+        Show();
+        Activate();
+        return _tcs.Task;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var udf = Path.Combine(Path.GetTempPath(), "XAU_WebView2");
+            var env = await CoreWebView2Environment.CreateAsync(null, udf);
+            await _web.EnsureCoreWebView2Async(env);
+            _web.CoreWebView2.NavigationStarting += OnNavStarting;
+            _web.CoreWebView2.Navigate(_authUrl);
+        }
+        catch (Exception ex)
+        {
+            WamAuthService.Diag("oauth window init: " + ex.Message);
+            _tcs.TrySetResult(null);
+            Close();
+        }
+    }
+
+    private void OnNavStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
+    {
+        if (_done || !e.Uri.StartsWith(_redirectUrl, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        _done = true;
+        var code = ExtractQueryValue(e.Uri, "code");
+        var error = ExtractQueryValue(e.Uri, "error");
+        if (error != null)
+            WamAuthService.Diag($"oauth redirect error: {error}");
+        _tcs.TrySetResult(code);
+        Dispatcher.BeginInvoke(new Action(Close));
+    }
+
+    private static string? ExtractQueryValue(string uri, string key)
+    {
+        var q = new Uri(uri).Query.TrimStart('?');
+        foreach (var pair in q.Split('&'))
+        {
+            var i = pair.IndexOf('=');
+            if (i <= 0) continue;
+            if (pair.Substring(0, i) == key)
+                return Uri.UnescapeDataString(pair.Substring(i + 1));
+        }
+        return null;
+    }
+}

--- a/XAU/Services/StatEditor/StatEditorService.cs
+++ b/XAU/Services/StatEditor/StatEditorService.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using XAU.Services.AutoUnlock;
+
+namespace XAU.Services.StatEditor
+{
+    public class HeroStat
+    {
+        public string Name { get; set; } = "";
+        public string DisplayName { get; set; } = "";
+        public string Value { get; set; } = "0";
+        public string StatType { get; set; } = "Integer";
+        public string Scid { get; set; } = "";
+    }
+
+    public sealed class StatEditorService
+    {
+        private static readonly HttpClient _http = CreateClient();
+        private readonly string _xauth;
+        private readonly string _xuid;
+
+        public StatEditorService(string xauth, string xuid)
+        {
+            _xauth = xauth;
+            _xuid = xuid;
+        }
+
+        private static HttpClient CreateClient()
+        {
+            var handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+            return new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+        }
+
+        private async Task<JObject> XboxFetchAsync(
+            HttpMethod method, string url, string contractVersion, string? jsonBody, CancellationToken token)
+        {
+            using var req = new HttpRequestMessage(method, url);
+            req.Headers.TryAddWithoutValidation("Authorization", _xauth);
+            req.Headers.TryAddWithoutValidation("x-xbl-contract-version", contractVersion);
+            req.Headers.TryAddWithoutValidation("Accept", "application/json");
+            req.Headers.TryAddWithoutValidation("Accept-Language", "en-US");
+            if (jsonBody != null)
+                req.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+            using var resp = await _http.SendAsync(req, token);
+            var text = await resp.Content.ReadAsStringAsync();
+            if (!resp.IsSuccessStatusCode)
+            {
+                var snippet = text.Length > 300 ? text.Substring(0, 300) : text;
+                throw new Exception($"Xbox API {(int)resp.StatusCode}: {snippet}");
+            }
+            if (string.IsNullOrWhiteSpace(text))
+                return new JObject();
+            return JObject.Parse(text);
+        }
+
+        public async Task<string?> DiscoverScidAsync(string titleId, CancellationToken token)
+        {
+            var url = $"https://titlehub.xboxlive.com/users/xuid({_xuid})/titles/titleHistory/decoration/Achievement,scid?maxItems=10000";
+            await XboxRateLimiter.StatsRead.WaitAsync(token);
+            var data = await XboxFetchAsync(HttpMethod.Get, url, "2", null, token);
+            var titles = data["titles"] as JArray;
+            if (titles == null)
+                return null;
+            foreach (var title in titles)
+            {
+                if (Child(title, "titleId")?.ToString() == titleId)
+                {
+                    return Child(Child(title, "detail"), "scid")?.ToString()
+                        ?? Child(title, "serviceConfigId")?.ToString();
+                }
+            }
+            return null;
+        }
+
+        public async Task<List<HeroStat>> ReadStatsAsync(string titleId, CancellationToken token)
+        {
+            var scid = await DiscoverScidAsync(titleId, token) ?? titleId;
+
+            var heroBody = JsonConvert.SerializeObject(new
+            {
+                arrangebyfield = "xuid",
+                xuids = new[] { _xuid },
+                groups = new[] { new { name = "Hero", titleId = titleId } }
+            });
+
+            JObject data;
+            await XboxRateLimiter.StatsRead.WaitAsync(token);
+            try
+            {
+                data = await XboxFetchAsync(HttpMethod.Post, "https://userstats.xboxlive.com/batch", "2", heroBody, token);
+            }
+            catch
+            {
+                var altBody = JsonConvert.SerializeObject(new
+                {
+                    requestedusers = new[] { _xuid },
+                    requestedscids = new[] { new { scid = scid, requestedstats = Array.Empty<string>() } }
+                });
+                await XboxRateLimiter.StatsRead.WaitAsync(token);
+                data = await XboxFetchAsync(HttpMethod.Post, "https://userstats.xboxlive.com/batch", "1", altBody, token);
+            }
+
+            return ParseBatchStats(data, scid);
+        }
+
+        public async Task<(bool ok, string message)> WriteStatAsync(
+            string titleId, string scid, string statName, string value, CancellationToken token)
+        {
+            if (string.IsNullOrWhiteSpace(scid))
+                return (false, "Cannot write a stat without a SCID.");
+
+            var url = $"https://statswrite.xboxlive.com/stats/users/{_xuid}/scids/{scid}";
+            Exception? lastError = null;
+
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                var unixTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ", CultureInfo.InvariantCulture);
+                var body = JsonConvert.SerializeObject(new Dictionary<string, object>
+                {
+                    ["$schema"] = "http://stats.xboxlive.com/2017-1/schema#",
+                    ["previousRevision"] = 0,
+                    ["revision"] = unixTime,
+                    ["timestamp"] = timestamp,
+                    ["stats"] = new Dictionary<string, object>
+                    {
+                        ["title"] = new Dictionary<string, object>
+                        {
+                            [statName] = new Dictionary<string, object> { ["value"] = value }
+                        }
+                    }
+                });
+
+                try
+                {
+                    await XboxRateLimiter.StatsWrite.WaitAsync(token);
+                    await XboxFetchAsync(new HttpMethod("PATCH"), url, "4", body, token);
+                    lastError = null;
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    lastError = ex;
+                    if (attempt < 2)
+                        await Task.Delay(1000, token);
+                }
+            }
+
+            if (lastError != null)
+                return (false, $"Stat write failed: {lastError.Message}");
+
+            var expected = value.Trim();
+            await Task.Delay(2000, token);
+            for (int attempt = 0; attempt < 5; attempt++)
+            {
+                var actual = await ReadExactStatAsync(scid, statName, token);
+                if (actual != null && actual.Trim() == expected)
+                    return (true, $"{statName} = {expected} confirmed.");
+                if (attempt < 4)
+                    await Task.Delay(1000, token);
+            }
+
+            return (false, $"Wrote {statName} but could not confirm the new value yet (Xbox may still be processing it).");
+        }
+
+        private async Task<string?> ReadExactStatAsync(string scid, string statName, CancellationToken token)
+        {
+            if (string.IsNullOrWhiteSpace(scid) || string.IsNullOrWhiteSpace(statName))
+                return null;
+            var url = $"https://userstats.xboxlive.com/users/xuid({_xuid})/scids/{scid}/stats/{Uri.EscapeDataString(statName)}?include=valuemetadata";
+            try
+            {
+                await XboxRateLimiter.StatsRead.WaitAsync(token);
+                var data = await XboxFetchAsync(HttpMethod.Get, url, "3", null, token);
+                var stats = data["stats"] as JArray;
+                if (stats != null)
+                {
+                    foreach (var s in stats)
+                    {
+                        var name = ValueAsString(s, new[] { "name", "statname", "statName" }, "");
+                        if (name == statName)
+                            return ValueAsString(s, new[] { "value" }, "0");
+                    }
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
+
+        // Só JObject aceita índice por nome; indexar JValue/JArray lança exceção.
+        private static JToken? Child(JToken? item, string key) => (item as JObject)?[key];
+
+        private static string ValueAsString(JToken? item, string[] keys, string fallback)
+        {
+            if (item is not JObject obj) return fallback;
+            foreach (var key in keys)
+            {
+                var v = obj[key];
+                if (v == null) continue;
+                if (v.Type == JTokenType.String) return v.ToString();
+                if (v.Type == JTokenType.Integer || v.Type == JTokenType.Float) return v.ToString();
+            }
+            return fallback;
+        }
+
+        private static HeroStat ParseStatItem(JToken stat, string collectionScid)
+        {
+            var name = ValueAsString(stat, new[] { "name", "statname", "statName" }, "");
+            var props = stat["groupproperties"] as JObject;
+            var displayName = props?["DisplayName"]?.ToString()
+                ?? props?["displayName"]?.ToString()
+                ?? ValueAsString(stat, new[] { "displayName", "displayname", "name", "statname", "statName" }, name);
+            return new HeroStat
+            {
+                Name = name,
+                DisplayName = string.IsNullOrEmpty(displayName) ? name : displayName,
+                Value = ValueAsString(stat, new[] { "value" }, "0"),
+                StatType = ValueAsString(stat, new[] { "type" }, "Integer"),
+                Scid = ValueAsString(stat, new[] { "scid" }, collectionScid)
+            };
+        }
+
+        private static void ParseStatCollection(JToken collection, string fallbackScid, List<HeroStat> stats)
+        {
+            var collectionScid = ValueAsString(collection, new[] { "scid" }, fallbackScid);
+            var statList = (Child(collection, "stats") ?? Child(collection, "statlist")) as JArray;
+            if (statList != null)
+                foreach (var stat in statList)
+                    stats.Add(ParseStatItem(stat, collectionScid));
+        }
+
+        private static List<HeroStat> ParseBatchStats(JObject data, string fallbackScid)
+        {
+            var stats = new List<HeroStat>();
+
+            if (data["groups"] is JArray groups)
+            {
+                foreach (var group in groups)
+                {
+                    var collections = (Child(group, "statlistscollection") ?? Child(group, "statlistcollection")) as JArray;
+                    if (collections != null)
+                        foreach (var c in collections)
+                            ParseStatCollection(c, fallbackScid, stats);
+                }
+            }
+
+            if (stats.Count == 0 && data["statlistscollection"] is JArray topCollections)
+                foreach (var c in topCollections)
+                    ParseStatCollection(c, fallbackScid, stats);
+
+            if (stats.Count == 0 && data["users"] is JArray users)
+                foreach (var user in users)
+                    if (Child(user, "scids") is JArray scids)
+                        foreach (var s in scids)
+                            ParseStatCollection(s, fallbackScid, stats);
+
+            return stats
+                .GroupBy(s => s.Name)
+                .Select(g => g.First())
+                .Where(s => !string.IsNullOrWhiteSpace(s.Name))
+                .ToList();
+        }
+    }
+}

--- a/XAU/Services/WamAuthService.cs
+++ b/XAU/Services/WamAuthService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
@@ -8,9 +9,8 @@ using Windows.Security.Credentials;
 
 namespace XAU.Services;
 
-// Replaces XboxAuthNet, the memory scanner, and the ETW events-token hack.
-// Flow: WAM (silent) → device.auth (RPS) → user.auth → xsts → device-bound XBL3.0 + events token.
-// No injection, no broker, no Xbox app dependency. Pure WAM + standard Xbox Live REST.
+// Fluxo: WAM (silencioso) → device.auth → user.auth → XSTS. Tokens device-bound (PoP):
+// WRITES levam header Signature ES256; reads nao. Sem injecao/broker/Xbox-app.
 public static class WamAuthService
 {
     private const string MsaProvider = "https://login.live.com";
@@ -19,20 +19,49 @@ public static class WamAuthService
     private const string Scope = "service::user.auth.xboxlive.com::MBI_SSL";
     private const string DeviceUrl = "https://device.auth.xboxlive.com/device/authenticate";
     private const string DeviceRp = "http://auth.xboxlive.com";
+    private const string TitleAuthUrl = "https://title.auth.xboxlive.com/title/authenticate";
     private const string UserUrl = "https://user.auth.xboxlive.com/user/authenticate";
     private const string XstsUrl = "https://xsts.auth.xboxlive.com/xsts/authorize";
     private const string XboxRp = "http://xboxlive.com";
     private const string EventsRp = "http://events.xboxlive.com";
+    private const string SisuUrl = "https://sisu.xboxlive.com/authorize";
+    private const string OAuthAuthorize = "https://login.live.com/oauth20_authorize.srf";
+    private const string OAuthToken = "https://login.live.com/oauth20_token.srf";
+    private const string OAuthDesktop = "https://login.live.com/oauth20_desktop.srf";
+    private const string UserAgent = "Mozilla/5.0 (XboxReplay; XboxLiveAuth/3.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36";
 
     private static readonly HttpClient Http = new();
-    private static string? _cachedXblToken, _cachedEventsToken, _cachedXuid, _cachedUhs;
+    // Client limpo (sem headers padrao) para o device-token assinado.
+    private static readonly HttpClient SignedHttp = new();
+    private static string? _cachedXblToken, _cachedEventsToken, _cachedXuid, _cachedUhs, _cachedSpoofToken;
     private static DateTime _cachedAt;
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(20);
-    private static PopCryptoProvider? _pop;  // saved for request signing
+    private static PopCryptoProvider? _pop;
+
+    public static string? LastError;
+    private static readonly string LogPath = Path.Combine(Path.GetTempPath(), "xau_wam_auth.log");
+    public static void Diag(string msg)
+    {
+        LastError = msg;
+        try { File.AppendAllText(LogPath, $"{DateTime.UtcNow:HH:mm:ss} {msg}{Environment.NewLine}"); } catch { }
+    }
 
     public static bool IsLoggedIn => !string.IsNullOrEmpty(_cachedXblToken) && DateTime.UtcNow - _cachedAt < Ttl;
     public static string? Xuid => _cachedXuid;
     public static string? Uhs => _cachedUhs;
+
+    // Adota um token gerado externamente (cache GDK do Xbox-app). Nao esta atrelado a
+    // nossa chave PoP, entao a assinatura fica desligada (_pop null → sem Signature).
+    public static void SetExternalToken(string xbl, string xuid, string uhs)
+    {
+        _pop = null;
+        _cachedXblToken = xbl;
+        _cachedSpoofToken = xbl;
+        _cachedXuid = xuid;
+        _cachedUhs = uhs;
+        _cachedAt = DateTime.UtcNow;
+        Diag($"external token set (xuid={xuid})");
+    }
 
     public static async Task<List<(string UserName, WebAccount Account)>> GetAccountsAsync()
     {
@@ -47,7 +76,7 @@ public static class WamAuthService
     {
         try
         {
-            // 1) WAM silent MSA token
+            // 1) Token MSA silencioso via WAM
             var provider = await WebAuthenticationCoreManager.FindAccountProviderAsync(MsaProvider, MsaAuthority);
             var request = new WebTokenRequest(provider, Scope, ClientId);
             var result = await WebAuthenticationCoreManager.GetTokenSilentlyAsync(request, account);
@@ -60,39 +89,272 @@ public static class WamAuthService
             Http.DefaultRequestHeaders.Add("x-xbl-contract-version", "2");
             Http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            // 2) Device token (broker's PC flow: RPS + MSA ticket + Windows version + PoP)
+            // 2) Device token (RPS) — atrela a identidade do device ao usuario logado.
             _pop = new PopCryptoProvider();
             var deviceToken = await GetDeviceTokenAsync(msaToken, _pop);
-            if (deviceToken == null) return false;
+            if (deviceToken == null) { Diag("device token failed"); return false; }
 
-            // 3) User token
+            // 3) User token — compartilhado pelos XSTS main + events.
             var (userToken, uhs) = await GetUserTokenAsync(msaToken);
-            if (userToken == null) return false;
+            if (userToken == null || string.IsNullOrEmpty(uhs)) { Diag("user token failed"); return false; }
 
-            // 4) XSTS for general RP (device-bound)
-            var (xsts, xuid) = await GetXstsAsync(userToken, deviceToken, XboxRp);
-            if (xsts == null) return false;
+            // 3b) Title token (opcional) — da ao XSTS main o title claim exigido por
+            //     WRITES de achievement + spoof de presenca. Segue sem ele em caso de falha.
+            var titleToken = await GetTitleTokenAsync(msaToken, deviceToken, _pop);
+            Diag(titleToken != null ? "title token OK" : "title token failed (continuing without)");
 
-            // 5) XSTS for events RP
-            var (eventsXsts, _) = await GetXstsAsync(userToken, deviceToken, EventsRp);
+            // 4) xauth principal = XSTS device-bound para xboxlive.com, com o title claim.
+            var (mainXsts, xuid, _) = await GetXstsAsync(userToken, deviceToken, XboxRp, titleToken);
+            if (mainXsts == null) { Diag("main XSTS failed"); return false; }
+            var xbl = $"XBL3.0 x={uhs};{mainXsts}";
 
-            // Cache
-            _cachedXblToken = $"XBL3.0 x={uhs};{xsts}";
+            // 5) Events token — XSTS para events.xboxlive.com.
+            var (eventsXsts, _, _) = await GetXstsAsync(userToken, deviceToken, EventsRp);
+
+            // Cache. O spoofer reusa o xauth principal (nao ha token de presenca separado).
+            _cachedXblToken = xbl;
+            _cachedSpoofToken = xbl;
             _cachedEventsToken = eventsXsts != null ? $"x:XBL3.0 x={uhs};{eventsXsts}" : null;
             _cachedXuid = xuid;
             _cachedUhs = uhs;
             _cachedAt = DateTime.UtcNow;
+            Diag("login OK");
             return true;
         }
-        catch { return false; }
+        catch (Exception e) { Diag("LoginAsync exception: " + e.Message); return false; }
+    }
+
+    // Login OAuth interativo → SISU. Autoriza device + title + user juntos e retorna
+    // token com title claim. Deve rodar na UI thread (abre janela WebView2).
+    public static async Task<bool> LoginWithSisuAsync()
+    {
+        try
+        {
+            // 1) OAuth interativo — o token que o SISU aceita.
+            var code = await GetOAuthCodeAsync();
+            if (string.IsNullOrEmpty(code)) { Diag("sisu: no oauth code"); return false; }
+            var accessToken = await ExchangeCodeAsync(code);
+            if (accessToken == null) { Diag("sisu: token exchange failed"); return false; }
+
+            // 2) Device token PoP anonimo (exigido pelo SISU).
+            _pop = new PopCryptoProvider();
+            var deviceToken = await GetPopDeviceTokenAsync(_pop);
+            if (deviceToken == null) { Diag("sisu: device token failed"); return false; }
+
+            // 3) SISU authorize (RP xboxlive.com) — xauth principal + tokens device/title/user.
+            var sisu = await SisuAuthorizeAsync(accessToken, deviceToken, _pop);
+            if (sisu.xbl == null || sisu.uhs == null) { Diag("sisu authorize failed"); return false; }
+
+            _cachedXblToken = sisu.xbl;
+            _cachedSpoofToken = sisu.xbl;
+            _cachedXuid = sisu.xuid;
+            _cachedUhs = sisu.uhs;
+
+            // 4) Token com presenca: XSTS dos tokens user+title+device do SISU para
+            //    xboxlive.com. Se gerar, usa ele no spoofer.
+            if (!string.IsNullOrEmpty(sisu.userToken))
+            {
+                var (pres, _, presUhs) = await GetXstsAsync(sisu.userToken!, deviceToken, XboxRp, sisu.titleToken);
+                if (pres != null && presUhs != null) _cachedSpoofToken = $"XBL3.0 x={presUhs};{pres}";
+
+                // 5) Events token.
+                var (ev, _, evUhs) = await GetXstsAsync(sisu.userToken!, deviceToken, EventsRp);
+                _cachedEventsToken = ev != null ? $"x:XBL3.0 x={evUhs};{ev}" : null;
+            }
+
+            _cachedAt = DateTime.UtcNow;
+            Diag($"login OK (SISU/OAuth) | title={(sisu.titleToken != null ? "yes" : "no")}");
+            return true;
+        }
+        catch (Exception e) { Diag("LoginWithSisu exception: " + e.Message); return false; }
+    }
+
+    // EXPERIMENTO: autoriza pelo provider WAM do Xbox Identity (xsts.auth.xboxlive.com),
+    // mesmo componente do Xbox app, que ja tem o enrollment do device desta maquina.
+    public static async Task<bool> LoginWithXboxProviderAsync()
+    {
+        try
+        {
+            var provider = await WebAuthenticationCoreManager.FindAccountProviderAsync("https://xsts.auth.xboxlive.com");
+            if (provider == null) { Diag("xbox provider: not found"); return false; }
+            Diag($"xbox provider: {provider.Id} / {provider.DisplayName}");
+
+            // Conta MSA para anexar (o provider Xbox se apoia em MSA).
+            WebAccount? account = null;
+            var msaProvider = await WebAuthenticationCoreManager.FindAccountProviderAsync(MsaProvider, MsaAuthority);
+            if (msaProvider != null)
+            {
+                var find = await WebAuthenticationCoreManager.FindAllAccountsAsync(msaProvider, ClientId);
+                account = find?.Accounts?.FirstOrDefault();
+            }
+
+            WebTokenRequest MakeReq(string target)
+            {
+                // Sem clientId — WAM rejeita clientId de app externo; o provider deriva.
+                var r = new WebTokenRequest(provider);
+                r.Properties.Add("Url", target);      // exigido pelo provider
+                r.Properties.Add("Target", target);
+                r.Properties.Add("Policy", "RETAIL");
+                return r;
+            }
+
+            bool Use(WebTokenRequestResult result, string how)
+            {
+                Diag($"xbox {how} status={result.ResponseStatus}");
+                if (result.ResponseStatus != WebTokenRequestStatus.Success)
+                {
+                    if (result.ResponseError != null)
+                        Diag($"  xbox err {result.ResponseError.ErrorCode}: {result.ResponseError.ErrorMessage}");
+                    return false;
+                }
+                var rd = result.ResponseData[0];
+                foreach (var kv in rd.Properties) Diag($"  xbox prop {kv.Key}={Trunc(kv.Value)}");
+                Diag($"  xbox token: {Trunc(rd.Token)}");
+                var token = rd.Token;
+                string xbl = token.StartsWith("XBL3.0") ? token
+                    : (rd.Properties.TryGetValue("UserHash", out var uh) || rd.Properties.TryGetValue("Uhs", out uh)) ? $"XBL3.0 x={uh};{token}"
+                    : $"XBL3.0 x=-;{token}";
+                _cachedXblToken = xbl;
+                _cachedSpoofToken = xbl;
+                if (rd.Properties.TryGetValue("XboxUserId", out var xid)) _cachedXuid = xid;
+                _cachedAt = DateTime.UtcNow;
+                Diag("login OK (Xbox WAM provider)");
+                return true;
+            }
+
+            // 1) Silencioso — funciona so se ja existe um grant.
+            foreach (var target in new[] { "http://xboxlive.com", "xboxlive.com" })
+            {
+                var result = account != null
+                    ? await WebAuthenticationCoreManager.GetTokenSilentlyAsync(MakeReq(target), account)
+                    : await WebAuthenticationCoreManager.GetTokenSilentlyAsync(MakeReq(target));
+                if (Use(result, $"silent target={target}")) return true;
+            }
+
+            // 2) Interativo — cria o consent/grant inicial. WAM desktop precisa do handle
+            //    da janela pai (o RequestTokenAsync simples lanca excecao).
+            try
+            {
+                var hwnd = IntPtr.Zero;
+                var win = System.Windows.Application.Current?.MainWindow;
+                if (win != null) hwnd = new System.Windows.Interop.WindowInteropHelper(win).Handle;
+                Diag($"xbox interactive: hwnd={hwnd}");
+                var result = await WamInterop.RequestTokenForWindowAsync(hwnd, MakeReq("http://xboxlive.com"));
+                if (Use(result, "interactive")) return true;
+            }
+            catch (Exception ie) { Diag("xbox interactive threw: " + ie.GetType().Name + ": " + ie.Message); }
+
+            return false;
+        }
+        catch (Exception e) { Diag("xbox provider exception: " + e.Message); return false; }
+    }
+
+    private static async Task<string?> GetOAuthCodeAsync()
+    {
+        var authUrl = OAuthAuthorize + "?" +
+            $"client_id={Uri.EscapeDataString(ClientId)}" +
+            $"&scope={Uri.EscapeDataString(Scope)}" +
+            "&response_type=code" +
+            $"&redirect_uri={Uri.EscapeDataString(OAuthDesktop)}" +
+            "&response_mode=query&prompt=select_account";
+        var window = new OAuthLoginWindow(authUrl, OAuthDesktop);
+        return await window.GetCodeAsync();
+    }
+
+    private static async Task<string?> ExchangeCodeAsync(string code)
+    {
+        var form = new Dictionary<string, string>
+        {
+            ["client_id"] = ClientId,
+            ["code"] = code,
+            ["grant_type"] = "authorization_code",
+            ["redirect_uri"] = OAuthDesktop,
+            ["scope"] = Scope
+        };
+        var req = new HttpRequestMessage(HttpMethod.Post, OAuthToken) { Content = new FormUrlEncodedContent(form) };
+        req.Headers.TryAddWithoutValidation("User-Agent", UserAgent);
+        using var resp = await SignedHttp.SendAsync(req);
+        var rb = await resp.Content.ReadAsStringAsync();
+        if (!resp.IsSuccessStatusCode) { Diag($"oauth token {(int)resp.StatusCode}: {Trunc(rb)}"); return null; }
+        return JsonDocument.Parse(rb).RootElement.GetProperty("access_token").GetString();
+    }
+
+    // Device token ProofOfPossession anonimo — o tipo exigido pelo SISU.
+    private static async Task<string?> GetPopDeviceTokenAsync(PopCryptoProvider pop)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            Properties = new
+            {
+                AuthMethod = "ProofOfPossession",
+                Id = "{" + Guid.NewGuid() + "}",
+                DeviceType = "Win32",
+                SerialNumber = "{" + Guid.NewGuid() + "}",
+                Version = "0.0.0",
+                ProofKey = pop.ProofKey
+            },
+            RelyingParty = DeviceRp,
+            TokenType = "JWT"
+        });
+        var req = new HttpRequestMessage(HttpMethod.Post, DeviceUrl) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+        req.Headers.Add("Signature", pop.SignRequest("POST", DeviceUrl, "", body));
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        using var resp = await SignedHttp.SendAsync(req);
+        var rb = await resp.Content.ReadAsStringAsync();
+        if (!resp.IsSuccessStatusCode) { Diag($"pop device {(int)resp.StatusCode}: {Trunc(rb)}"); return null; }
+        return JsonDocument.Parse(rb).RootElement.GetProperty("Token").GetString();
+    }
+
+    // SISU /authorize — assinado, sem x-xbl-contract-version. Retorna o authorization
+    // token e os tokens device/title/user subjacentes.
+    private static async Task<(string? xbl, string? xuid, string? uhs, string? userToken, string? titleToken)> SisuAuthorizeAsync(string accessToken, string deviceToken, PopCryptoProvider pop)
+    {
+        try
+        {
+            var body = JsonSerializer.Serialize(new
+            {
+                AccessToken = "t=" + accessToken,
+                AppId = ClientId,
+                DeviceToken = deviceToken,
+                Sandbox = "RETAIL",
+                UseModernGamertag = true,
+                SiteName = "user.auth.xboxlive.com",
+                RelyingParty = XboxRp,
+                ProofKey = pop.ProofKey
+            });
+            var req = new HttpRequestMessage(HttpMethod.Post, SisuUrl) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+            req.Headers.Add("Signature", pop.SignRequest("POST", SisuUrl, "", body));
+            req.Headers.TryAddWithoutValidation("User-Agent", UserAgent);
+            req.Headers.Add("Accept", "application/json");
+            using var resp = await SignedHttp.SendAsync(req);
+            var rb = await resp.Content.ReadAsStringAsync();
+            if (!resp.IsSuccessStatusCode) { Diag($"SISU {(int)resp.StatusCode}: {Trunc(rb)}"); return (null, null, null, null, null); }
+            var root = JsonDocument.Parse(rb).RootElement;
+            var auth = root.GetProperty("AuthorizationToken");
+            var token = auth.GetProperty("Token").GetString();
+            var xui = auth.GetProperty("DisplayClaims").GetProperty("xui")[0];
+            var uhs = xui.GetProperty("uhs").GetString();
+            var xuid = xui.TryGetProperty("xid", out var x) ? x.GetString() : null;
+            var userToken = root.TryGetProperty("UserToken", out var ut) && ut.TryGetProperty("Token", out var utt) ? utt.GetString() : null;
+            var titleToken = root.TryGetProperty("TitleToken", out var tt) && tt.TryGetProperty("Token", out var ttt) ? ttt.GetString() : null;
+            return ($"XBL3.0 x={uhs};{token}", xuid, uhs, userToken, titleToken);
+        }
+        catch (Exception e) { Diag("SISU exception: " + e.Message); return (null, null, null, null, null); }
     }
 
     public static string? GetXblToken() => IsLoggedIn ? _cachedXblToken : null;
     public static string? GetEventsToken() => IsLoggedIn ? _cachedEventsToken : null;
+    // Token usado pelo spoofer (atualmente o xauth principal).
+    public static string? GetSpoofToken() => IsLoggedIn ? (_cachedSpoofToken ?? _cachedXblToken) : null;
 
     public static string? SignRequest(string method, string uri, string body) =>
         _pop?.SignRequest(method, uri, _cachedXblToken ?? "", body);
 
+    // O campo token da assinatura precisa bater com o header Authorization enviado pelo spoofer.
+    public static string? SignSpoofRequest(string method, string uri, string body) =>
+        _pop?.SignRequest(method, uri, GetSpoofToken() ?? "", body);
+
+    // Device token: AuthMethod RPS, atrelado ao ticket MSA do usuario e a chave PoP.
     private static async Task<string?> GetDeviceTokenAsync(string msaToken, PopCryptoProvider pop)
     {
         var v = Environment.OSVersion.Version;
@@ -106,9 +368,28 @@ public static class WamAuthService
         var req = new HttpRequestMessage(HttpMethod.Post, DeviceUrl) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
         req.Headers.Add("Signature", pop.SignRequest("POST", DeviceUrl, "", body));
         req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        using var resp = await Http.SendAsync(req);
-        if (!resp.IsSuccessStatusCode) return null;
+        using var resp = await SignedHttp.SendAsync(req);
         var rb = await resp.Content.ReadAsStringAsync();
+        if (!resp.IsSuccessStatusCode) { Diag($"device {(int)resp.StatusCode}: {Trunc(rb)}"); return null; }
+        return JsonDocument.Parse(rb).RootElement.GetProperty("Token").GetString();
+    }
+
+    // Title token via title.auth (RPS + device token, assinado). Carrega title claim
+    // para o XSTS autorizar writes de achievement. Opcional: null em caso de falha.
+    private static async Task<string?> GetTitleTokenAsync(string msaToken, string deviceToken, PopCryptoProvider pop)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            Properties = new { AuthMethod = "RPS", DeviceToken = deviceToken, RpsTicket = "t=" + msaToken, SiteName = "user.auth.xboxlive.com", ProofKey = pop.ProofKey },
+            RelyingParty = DeviceRp,
+            TokenType = "JWT"
+        });
+        var req = new HttpRequestMessage(HttpMethod.Post, TitleAuthUrl) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+        req.Headers.Add("Signature", pop.SignRequest("POST", TitleAuthUrl, "", body));
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        using var resp = await SignedHttp.SendAsync(req);
+        var rb = await resp.Content.ReadAsStringAsync();
+        if (!resp.IsSuccessStatusCode) { Diag($"title.auth {(int)resp.StatusCode}: {Trunc(rb)}"); return null; }
         return JsonDocument.Parse(rb).RootElement.GetProperty("Token").GetString();
     }
 
@@ -126,20 +407,22 @@ public static class WamAuthService
         return (d.GetProperty("Token").GetString(), d.GetProperty("DisplayClaims").GetProperty("xui")[0].GetProperty("uhs").GetString() ?? "");
     }
 
-    private static async Task<(string? token, string? xuid)> GetXstsAsync(string userToken, string deviceToken, string rp)
+    private static async Task<(string? token, string? xuid, string? uhs)> GetXstsAsync(string userToken, string deviceToken, string rp, string? titleToken = null)
     {
-        var body = JsonSerializer.Serialize(new
-        {
-            Properties = new { SandboxId = "RETAIL", UserTokens = new[] { userToken }, DeviceToken = deviceToken },
-            RelyingParty = rp,
-            TokenType = "JWT"
-        });
+        object props = string.IsNullOrEmpty(titleToken)
+            ? new { SandboxId = "RETAIL", UserTokens = new[] { userToken }, DeviceToken = deviceToken }
+            : new { SandboxId = "RETAIL", UserTokens = new[] { userToken }, DeviceToken = deviceToken, TitleToken = titleToken };
+        var body = JsonSerializer.Serialize(new { Properties = props, RelyingParty = rp, TokenType = "JWT" });
         var (code, resp) = await PostAsync(XstsUrl, body);
-        if (code != 200) return (null, null);
+        if (code != 200) { Diag($"XSTS({rp}) {code}: {Trunc(resp)}"); return (null, null, null); }
         var d = JsonDocument.Parse(resp).RootElement;
         var xui = d.GetProperty("DisplayClaims").GetProperty("xui")[0];
-        return (d.GetProperty("Token").GetString(), xui.TryGetProperty("xid", out var x) ? x.GetString() : null);
+        return (d.GetProperty("Token").GetString(),
+                xui.TryGetProperty("xid", out var x) ? x.GetString() : null,
+                xui.TryGetProperty("uhs", out var u) ? u.GetString() : null);
     }
+
+    private static string Trunc(string s) => s.Length > 400 ? s.Substring(0, 400) : s;
 
     private static async Task<(int code, string body)> PostAsync(string url, string json)
     {
@@ -148,7 +431,7 @@ public static class WamAuthService
     }
 }
 
-// EC P-256 proof-of-possession: ephemeral keypair, JWK ProofKey, ES256 signature.
+// Proof-of-possession EC P-256: par de chaves efemero, ProofKey JWK, assinatura ES256.
 sealed class PopCryptoProvider
 {
     private readonly ECDsa _signer = ECDsa.Create(ECCurve.NamedCurves.nistP256);

--- a/XAU/Services/WamInterop.cs
+++ b/XAU/Services/WamInterop.cs
@@ -1,0 +1,43 @@
+using System.Runtime.InteropServices;
+using Windows.Foundation;
+using Windows.Security.Authentication.Web.Core;
+using WinRT;
+
+namespace XAU.Services;
+
+// WAM no desktop nao mostra UI interativa sem janela pai, e o WinRT
+// RequestTokenAsync lanca excecao. O caminho suportado e a interface COM
+// IWebAuthenticationCoreManagerInterop (recebe um HWND). O .NET moderno nao tem mais
+// marshaling de IInspectable/[ComImport], entao chamamos a vtable direto via CsWinRT.
+internal static class WamInterop
+{
+    private static readonly Guid InteropIid = new("F4B8E804-811E-4436-B69C-44CB67B72084");
+    private const string ClassName = "Windows.Security.Authentication.Web.Core.WebAuthenticationCoreManager";
+
+    // Layout da vtable: 0-2 IUnknown, 3-5 IInspectable, 6 RequestTokenForWindowAsync.
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int RequestTokenForWindow(IntPtr thisPtr, IntPtr appWindow, IntPtr request, ref Guid riid, out IntPtr asyncOp);
+
+    public static async Task<WebTokenRequestResult> RequestTokenForWindowAsync(IntPtr hwnd, WebTokenRequest request)
+    {
+        using var interop = ActivationFactory.Get(ClassName, InteropIid);
+        var thisPtr = interop.ThisPtr;
+        var vtbl = Marshal.ReadIntPtr(thisPtr);
+        var methodPtr = Marshal.ReadIntPtr(vtbl, 6 * IntPtr.Size);
+        var fn = Marshal.GetDelegateForFunctionPointer<RequestTokenForWindow>(methodPtr);
+
+        var requestPtr = MarshalInspectable<WebTokenRequest>.FromManaged(request);
+        try
+        {
+            var asyncIid = GuidGenerator.CreateIID(typeof(IAsyncOperation<WebTokenRequestResult>));
+            var hr = fn(thisPtr, hwnd, requestPtr, ref asyncIid, out var asyncOpPtr);
+            Marshal.ThrowExceptionForHR(hr);
+            var op = MarshalInterface<IAsyncOperation<WebTokenRequestResult>>.FromAbi(asyncOpPtr);
+            return await op;
+        }
+        finally
+        {
+            MarshalInspectable<WebTokenRequest>.DisposeAbi(requestPtr);
+        }
+    }
+}

--- a/XAU/Util/Constants/Constants.cs
+++ b/XAU/Util/Constants/Constants.cs
@@ -1,4 +1,4 @@
-// Minimize total number of string allocations if .NET runtime is opting to not intern them
+// Minimiza alocações de string caso o runtime .NET opte por não internar
 struct StringConstants
 {
     public const string Gamerscore = @"Gamerscore";
@@ -33,7 +33,6 @@ struct HeaderValues
 
 struct OpenableLinks
 {
-    // Hardcoded links to socials
     public const string Discord = @"https://discord.gg/fCqM7287jG";
     public const string GitHubUserUrl = @"https://github.com/ItsLogic";
     public const string EventsDocumentationUrl = @"https://github.com/Fumo-Unlockers/Xbox-Achievement-Unlocker/blob/Main/Doc/Events.md";
@@ -41,12 +40,13 @@ struct OpenableLinks
 
 struct Hosts
 {
-    // Xbox Live Header Host Values
     public const string Achievements = @"achievements.xboxlive.com";
     public const string Profile = @"profile.xboxlive.com";
     public const string PeopleHub = @"peoplehub.xboxlive.com";
     public const string TitleHub = @"titlehub.xboxlive.com";
     public const string Telemetry = @"v20.events.data.microsoft.com";
+    public const string PresenceHeartbeat = @"presence-heartbeat.xboxlive.com";
+    public const string UserPresence = @"userpresence.xboxlive.com";
     public const string GitHubApi = @"api.github.com";
     public const string GitHubRaw = @"raw.githubusercontent.com";
 
@@ -64,7 +64,7 @@ public struct BasicXboxAPIUris
 
 public struct InterpolatedXboxAPIUrls
 {
-    // TODO: could uri build things
+    // TODO: dava pra montar as URIs via UriBuilder
     public const string GamepassMembershipUrl = "https://xgrant.xboxlive.com/users/xuid({0})/programInfo?filter=profile,activities,catalog";
     public const string ProfileUrl = "https://peoplehub.xboxlive.com/users/me/people/xuids({0})/decoration/detail,preferredColor,presenceDetail,multiplayerSummary";
     public const string TitleUrl = "https://titlehub.xboxlive.com/users/xuid({0})/titles/batch/decoration/GamePass,Achievement,Stats";
@@ -72,7 +72,7 @@ public struct InterpolatedXboxAPIUrls
     public const string QueryAchievementsUrl = "https://achievements.xboxlive.com/users/xuid({0})/achievements?titleId={1}&maxItems=1000";
     public const string QueryAchievements360Url = "https://achievements.xboxlive.com/users/xuid({0})/titleachievements?titleId={1}&maxItems=1000";
     public const string UpdateAchievementsUrl = "https://achievements.xboxlive.com/users/xuid({0})/achievements/{1}/update";
-    public const string HeartbeatUrl = "https://userpresence.xboxlive.com/users/xuid({0})/devices/current/titles/current";
+    public const string HeartbeatUrl = "https://presence-heartbeat.xboxlive.com/users/xuid({0})/devices/current/";
     public const string GamertagSearch = "https://profile.xboxlive.com/users/gt({0})/profile/settings?settings=GameDisplayPicRaw,Gamerscore,Gamertag";
 }
 

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -10,7 +10,11 @@ using Wpf.Ui.Controls;
 using Wpf.Ui.Common;
 using Wpf.Ui.Contracts;
 using Wpf.Ui.Services;
-using XAU.Views.Pages;
+using System.Threading;
+using XAU.AutoUnlock;
+using XAU.Services.AutoUnlock;
+// System.Windows.Forms é importado globalmente; fixa "Application" no WPF para evitar ambiguidade.
+using Application = System.Windows.Application;
 
 namespace XAU.ViewModels.Pages
 {
@@ -25,6 +29,7 @@ namespace XAU.ViewModels.Pages
         [ObservableProperty] public string _gameInfo = "";
         [ObservableProperty] private string _gameName = "";
         [ObservableProperty] private bool _isUnlockAllEnabled = false;
+        [ObservableProperty] private bool _isAutoUnlockerEnabled = false;
         [ObservableProperty] private string _searchText = "";
         public static string TitleID = "0";
         private bool IsTitleIDValid = false;
@@ -35,25 +40,28 @@ namespace XAU.ViewModels.Pages
         private Dictionary<int, DGAchievement> _unlockedAchievements = new Dictionary<int, DGAchievement>();
 
         private GameTitle GameInfoResponse = new GameTitle();
-        // TODO: this needs to be updated if language changes
+        // Protege todo acesso a Titles[0] contra lista vazia.
+        private string CurrentGameName => GameInfoResponse.Titles.Any() ? GameInfoResponse.Titles[0].Name : GameName;
+        // TODO: precisa ser atualizado se o idioma mudar
         private Lazy<XboxRestAPI> _xboxRestAPI = new Lazy<XboxRestAPI>(() => new XboxRestAPI(HomeViewModel.XAUTH));
 
         public static bool SpoofingUpdate = false;
+        private bool IsFiltered = false;
         private bool IsEventBased = false;
         private dynamic EventsData = (dynamic)(new JObject());
         public static string EventsToken;
 
-        public AchievementsViewModel(ISnackbarService snackbarService, IContentDialogService contentDialogService, INavigationService navigationService)
+        public AchievementsViewModel(ISnackbarService snackbarService, IContentDialogService contentDialogService)
         {
             _snackbarService = snackbarService;
             _contentDialogService = contentDialogService;
-            _navigationService = navigationService;
         }
 
         private readonly IContentDialogService _contentDialogService;
         private readonly ISnackbarService _snackbarService;
-        private readonly INavigationService _navigationService;
         private TimeSpan _snackbarDuration = TimeSpan.FromSeconds(2);
+        // Jogos para os quais já oferecemos retomar o unlock nesta sessão.
+        private readonly HashSet<string> _resumePrompted = new HashSet<string>();
 
         public class DGAchievement
         {
@@ -68,6 +76,10 @@ namespace XAU.ViewModels.Pages
             public string? RarityCategory { get; set; }
             public string? ProgressState { get; set; }
             public bool IsUnlockable { get; set; }
+            // Rótulo "Easy Unlock"/"Hard Unlock" (vazio em jogos comuns).
+            public string Category { get; set; } = "";
+            // Marca de verificação: "" / "⏳" (pendente) / "✓" (confirmado).
+            public string VerifyState { get; set; } = "";
         }
         public async void OnNavigatedTo()
         {
@@ -86,12 +98,12 @@ namespace XAU.ViewModels.Pages
                         if (HomeViewModel.SpoofedTitleID == TitleIDOverride)
                         {
                             GameInfo = "Manually Spoofing";
-                            GameName = GameInfoResponse.Titles[0].Name;
+                            GameName = CurrentGameName;
                         }
                         else
                         {
                             GameInfo = "Spoofing Another Game";
-                            GameName = GameInfoResponse.Titles[0].Name;
+                            GameName = CurrentGameName;
                         }
 
                     }
@@ -128,12 +140,12 @@ namespace XAU.ViewModels.Pages
             TitleIDEnabled = true;
             IsInitialized = true;
             NewGame = false;
+            await CheckResumeAsync();
         }
 
 
         private async Task LoadGameInfo()
         {
-            // Check for a valid TitleID and set overrides
             if (TitleID != "0")
             {
                 TitleIDOverride = TitleID;
@@ -142,16 +154,17 @@ namespace XAU.ViewModels.Pages
 
             GameInfo = string.Empty;
 
-            // Fetch game information
             var gameInfoResponse = await _xboxRestAPI.Value.GetGameTitleAsync(HomeViewModel.XUIDOnly, TitleIDOverride);
 
-            // Handle response validation and set properties accordingly
             if (gameInfoResponse?.Titles?.Any() != true)
             {
                 GameName = "Error";
                 IsTitleIDValid = false;
                 return;
             }
+
+            // Campo lido pela UI de spoof (SpoofGame / OnNavigatedTo); sem isto, indexavam Titles vazio e quebravam.
+            GameInfoResponse = gameInfoResponse;
 
             var gameTitle = gameInfoResponse.Titles.FirstOrDefault();
             if (gameTitle != null)
@@ -169,12 +182,12 @@ namespace XAU.ViewModels.Pages
                 if (HomeViewModel.SpoofedTitleID == TitleIDOverride)
                 {
                     GameInfo = "Manually Spoofing";
-                    GameName = GameInfoResponse.Titles[0].Name;
+                    GameName = CurrentGameName;
                 }
                 else
                 {
                     GameInfo = "Spoofing Another Game";
-                    GameName = GameInfoResponse.Titles[0].Name;
+                    GameName = CurrentGameName;
                 }
             }
             else
@@ -184,7 +197,7 @@ namespace XAU.ViewModels.Pages
                 GameInfo = "Auto Spoofing";
                 if (GameInfoResponse.Titles.Any())
                 {
-                    GameName = GameInfoResponse.Titles[0].Name;
+                    GameName = CurrentGameName;
                 }
 
                 await Task.Run(() => Spoofing());
@@ -193,12 +206,12 @@ namespace XAU.ViewModels.Pages
                     if (HomeViewModel.SpoofedTitleID == HomeViewModel.AutoSpoofedTitleID)
                     {
                         GameInfo = "Manually Spoofing";
-                        GameName = GameInfoResponse.Titles[0].Name;
+                        GameName = CurrentGameName;
                     }
                     else
                     {
                         GameInfo = "Spoofing Another Game";
-                        GameName = GameInfoResponse.Titles[0].Name;
+                        GameName = CurrentGameName;
                     }
                 }
                 HomeViewModel.AutoSpoofedTitleID = "0";
@@ -210,12 +223,26 @@ namespace XAU.ViewModels.Pages
         public async Task Spoofing()
         {
             await _xboxRestAPI.Value.SendHeartbeatAsync(HomeViewModel.XUIDOnly, HomeViewModel.AutoSpoofedTitleID);
+            var i = 0;
+            Thread.Sleep(1000);
             SpoofingUpdate = false;
             while (!SpoofingUpdate)
             {
-                await Task.Delay(TimeSpan.FromSeconds(300));
-                if (SpoofingUpdate) break;
-                await _xboxRestAPI.Value.SendHeartbeatAsync(HomeViewModel.XUIDOnly, HomeViewModel.AutoSpoofedTitleID);
+                if (i == 300)
+                {
+                    await _xboxRestAPI.Value.SendHeartbeatAsync(HomeViewModel.XUIDOnly, HomeViewModel.AutoSpoofedTitleID);
+                    i = 0;
+                }
+                else
+                {
+                    if (SpoofingUpdate)
+                    {
+
+                        break;
+                    }
+                    i++;
+                }
+                Thread.Sleep(1000);
             }
         }
 
@@ -224,8 +251,8 @@ namespace XAU.ViewModels.Pages
 
             Achievements.Clear();
             DGAchievements.Clear();
-            // clears unlocked achievements from dictionary
             _unlockedAchievements.Clear();
+            IsAutoUnlockerEnabled = false;
             if (!IsTitleIDValid)
                 return;
             if (!IsSelectedGame360)
@@ -255,7 +282,6 @@ namespace XAU.ViewModels.Pages
                 }
                 for (int i = 0; i < AchievementResponse.achievements.Count; i++)
                 {
-                    //absolutely fucking dogwater event based check
                     if (AchievementResponse.achievements[i].progression.requirements.Any())
                     {
                         if (AchievementResponse.achievements[i].progression.requirements[0].id !=
@@ -282,7 +308,6 @@ namespace XAU.ViewModels.Pages
                         rewarddescriptionplaceholder = AchievementResponse.achievements[i].rewards[0].description;
                         rewardvalueplaceholder = AchievementResponse.achievements[i].rewards[0].value;
                         rewardtypeplaceholder = AchievementResponse.achievements[i].rewards[0].type;
-                        //rewardmediaAssetplaceholder = AchievementResponse.achievements[i].rewards[0].mediaAsset;
                         rewardvalueTypeplaceholder = AchievementResponse.achievements[i].rewards[0].valueType;
                     }
                     catch
@@ -347,9 +372,8 @@ namespace XAU.ViewModels.Pages
                     }
                     );
                 }
-                for (int dgIdx = 0; dgIdx < Achievements.Count; dgIdx++)
+                foreach (var achievement in Achievements)
                 {
-                    var achievement = Achievements[dgIdx];
                     var gamerscore = 0;
                     if (achievement.rewards[0].type == StringConstants.Gamerscore)
                     {
@@ -357,7 +381,7 @@ namespace XAU.ViewModels.Pages
                     }
                     DGAchievements.Add(new DGAchievement()
                     {
-                        Index = dgIdx,
+                        Index = Achievements.IndexOf(achievement),
                         ID = int.Parse(achievement.id),
                         Name = achievement.name,
                         Description = achievement.description,
@@ -381,7 +405,7 @@ namespace XAU.ViewModels.Pages
                     LoadAchievements();
                     return;
                 }
-                //cut down version of the code to display minimal information about 360 achievements
+                // Versão reduzida: exibe informação mínima das conquistas do 360.
                 for (int i = 0; i < Xbox360AchievementResponse?.achievements.Count; i++)
                 {
                     var rewards = new AchievementRewards
@@ -407,9 +431,8 @@ namespace XAU.ViewModels.Pages
                     }
                     );
                 }
-                for (int dgIdx = 0; dgIdx < Achievements.Count; dgIdx++)
+                foreach (var achievement in Achievements)
                 {
-                    var achievement = Achievements[dgIdx];
                     var gamerscore = 0;
                     if (achievement.rewards[0].type == "Gamerscore")
                     {
@@ -417,7 +440,7 @@ namespace XAU.ViewModels.Pages
                     }
                     DGAchievements.Add(new DGAchievement()
                     {
-                        Index = dgIdx,
+                        Index = Achievements.IndexOf(achievement),
                         ID = int.Parse(achievement.id),
                         Name = achievement.name,
                         Description = achievement.description,
@@ -443,7 +466,6 @@ namespace XAU.ViewModels.Pages
 
             if (IsEventBased)
             {
-                //Event based logic
                 string DataPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\\XAU\\Events\\Data.json";
                 var data = JObject.Parse(File.ReadAllText(DataPath));
                 JArray SupportedGamesJ = (JArray)data["SupportedTitleIDs"];
@@ -452,13 +474,33 @@ namespace XAU.ViewModels.Pages
                 {
                     Unlockable = true;
                     EventsData = (dynamic)(JObject)data[TitleIDOverride];
+                    var gameNode = (JObject)data[TitleIDOverride];
+                    var achNode = gameNode?["Achievements"] as JObject;
+                    int noDataCount = 0;
                     foreach (var achievement in DGAchievements)
                     {
-                        if (EventsData.Achievements.ContainsKey(achievement.ID.ToString()) && achievement.ProgressState != StringConstants.Achieved)
-                        {
+                        var achId = achievement.ID.ToString();
+                        bool hasData = achNode != null && achNode[achId] != null;
+
+                        if (hasData && achievement.ProgressState != StringConstants.Achieved)
                             achievement.IsUnlockable = true;
+
+                        // Coluna Category: vazio se já obtida, "No Data" sem entrada no template, senão Easy/Hard.
+                        if (achievement.ProgressState == StringConstants.Achieved)
+                            achievement.Category = "";
+                        else if (!hasData)
+                        {
+                            achievement.Category = "No Data";
+                            noDataCount++;
                         }
+                        else
+                            achievement.Category = CategoryDetector.Label(CategoryDetector.Detect(achNode[achId]));
                     }
+
+                    if (noDataCount > 0)
+                        _snackbarService.Show("Some achievements have no event data",
+                            $"{noDataCount} achievement(s) have no event data and may not unlock. They're marked \"No Data\".",
+                            ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
                 }
                 CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
             }
@@ -480,6 +522,9 @@ namespace XAU.ViewModels.Pages
                 IsUnlockAllEnabled = Unlockable;
             else
                 IsUnlockAllEnabled = false;
+
+            IsAutoUnlockerEnabled = IsTitleIDValid && !IsSelectedGame360 && DGAchievements.Count > 0;
+            AutoHasOrder = IsAutoUnlockerEnabled && OrderRepository.Exists(TitleIDOverride);
         }
 
         public async void UnlockAchievement(int AchievementIndex)
@@ -496,7 +541,7 @@ namespace XAU.ViewModels.Pages
                     DGAchievements[AchievementIndex].ProgressState = StringConstants.Achieved;
                     DGAchievements[AchievementIndex].DateUnlocked = DateTime.Now;
 
-                    // Add achievement to the dictionary. this will fix search & filter unlockable state
+                    // Adiciona ao dicionário para corrigir o estado de unlockable na busca/filtro.
                     var unlockedAchievement = DGAchievements[AchievementIndex];
                     unlockedAchievement.IsUnlockable = false;
                     unlockedAchievement.ProgressState = StringConstants.Achieved;
@@ -506,6 +551,10 @@ namespace XAU.ViewModels.Pages
                     {
                         _unlockedAchievements.Add(unlockedAchievement.ID, unlockedAchievement);
                     }
+
+                    // Verifica se realmente aplicou (marca ✓ ao confirmar).
+                    DGAchievements[AchievementIndex].VerifyState = "⏳";
+                    _ = VerifyAndMarkBatchAsync(new List<string> { unlockedAchievement.ID.ToString() }, eventBased: false, announce: false);
 
                     CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
                 }
@@ -524,76 +573,70 @@ namespace XAU.ViewModels.Pages
                         new SimpleContentDialogCreateOptions()
                         {
                             Title = "Error: You have not set an events token",
-                            Content = "To unlock event based games you must supply an events token. Log in via WAM to obtain one.",
-                            PrimaryButtonText = "Go to Settings",
+                            Content = "To unlock event based games you must supply an events token. Please refer to the guide for more information.\nPressing the \"Open Guide\" button will open the documentation and guide in your default browser.",
+                            PrimaryButtonText = "Open Guide",
                             CloseButtonText = "Close",
                         });
 
-                    if (result == ContentDialogResult.Primary)
-                        _navigationService.Navigate(typeof(SettingsPage));
-
+                    switch (result)
+                    {
+                        case ContentDialogResult.Primary:
+                            var sInfo = new System.Diagnostics.ProcessStartInfo(OpenableLinks.EventsDocumentationUrl)
+                            {
+                                UseShellExecute = true,
+                            };
+                            System.Diagnostics.Process.Start(sInfo);
+                            break;
+                    }
                     return;
                 }
 
-                // TODO: move this over to the rest api?
-                var requestbody = File.ReadAllText(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + $"\\XAU\\Events\\{TitleIDOverride}.json");
-                DateTime timestamp = DateTime.UtcNow;
-                foreach (var i in EventsData.Achievements[DGAchievements[AchievementIndex].ID.ToString()])
-                {
-                    var ReplacementData = i.Value;
-                    switch (ReplacementData.ReplacementType.ToString())
-                    {
-                        case "Replace":
-                            {
-                                requestbody = requestbody.Replace(ReplacementData.Target.ToString(), ReplacementData.Replacement.ToString());
-                                break;
-                            }
-                        case "RangeInt":
-                            {
-                                int min = ReplacementData.Min;
-                                int max = ReplacementData.Max;
-                                Random random = new Random();
-                                int randomint = random.Next(min, max);
-                                requestbody = requestbody.Replace(ReplacementData.Target.ToString(), randomint.ToString());
-                                break;
-                            }
-                        case "RangeFloat":
-                            {
-                                float min = ReplacementData.Min;
-                                float max = ReplacementData.Max;
-                                Random random = new Random();
-                                float randomfloat = (float)random.NextDouble() * (max - min) + min;
-                                requestbody = requestbody.Replace(ReplacementData.Target.ToString(), randomfloat.ToString());
-                                break;
-                            }
-                        case "StupidFuckingLDAPTimestamp":
-                            {
-                                long ldapTimestamp = DateTime.Now.ToFileTime();
-                                requestbody = requestbody.Replace(ReplacementData.Target.ToString(), ldapTimestamp.ToString());
-                                break;
-                            }
-                        default:
-                            {
-                                _snackbarService.Show("Error: Bad Achievement Data", "Something went wrong with the achievement data", ControlAppearance.Danger,
-                                                                                  new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
-                                return;
-                            }
-
-                    }
-                }
-                requestbody = requestbody.Replace("REPLACETIME", timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
-                requestbody = requestbody.Replace("REPLACESEQ", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString());
-                requestbody = requestbody.Replace("REPLACEXUID", HomeViewModel.XUIDOnly);
-                requestbody = JObject.Parse(requestbody).ToString(Formatting.None);
-                var bodyconverted = new StringContent(requestbody, Encoding.UTF8, "application/x-json-stream");
+                // O event unlocker monta o corpo (Easy ou Hard) e envia, então unlock manual e automático compartilham o mesmo caminho.
+                var achId = DGAchievements[AchievementIndex].ID.ToString();
                 try
                 {
-                    await _xboxRestAPI.Value.UnlockEventBasedAchievement(EventsToken, bodyconverted);
+                    // Conquistas de contador (target > 1): sonda, mede e completa até o alvo. As demais usam o multiplicador "Loop ×".
+                    if (LooksLikeCounter(achId))
+                    {
+                        var cu = new CounterUnlocker(_xboxRestAPI.Value, TitleIDOverride, HomeViewModel.XUIDOnly, EventsToken);
+                        var cr = await cu.RunAsync(achId, (JObject)EventsData, CancellationToken.None);
+                        if (cr == CounterResult.Failed)
+                        {
+                            _snackbarService.Show("Error: Achievement Not Unlocked",
+                                $"{DGAchievements[AchievementIndex].Name} was not unlocked", ControlAppearance.Danger,
+                                new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+                            return;
+                        }
+                        if (cr != CounterResult.NotCounter)
+                        {
+                            DGAchievements[AchievementIndex].IsUnlockable = false;
+                            if (cr == CounterResult.Achieved)
+                            {
+                                DGAchievements[AchievementIndex].ProgressState = StringConstants.Achieved;
+                                DGAchievements[AchievementIndex].DateUnlocked = DateTime.Now;
+                                _snackbarService.Show("Achievement Unlocked", $"{DGAchievements[AchievementIndex].Name} has been unlocked",
+                                    ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
+                            }
+                            else
+                            {
+                                _snackbarService.Show("Counter sent — pending",
+                                    $"{DGAchievements[AchievementIndex].Name} events sent; Xbox may still be processing.",
+                                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                            }
+                            CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+                            return;
+                        }
+                        // NotCounter -> cai no event unlock normal abaixo.
+                    }
+
+                    int multiplier = int.TryParse(AutoLoopCount?.Trim(), out var m) && m > 0 ? m : 1;
+                    var eventUnlocker = new EventUnlocker(_xboxRestAPI.Value, TitleIDOverride, HomeViewModel.XUIDOnly, EventsToken);
+                    await eventUnlocker.UnlockAsync(achId, (JObject)EventsData, multiplier);
 
                     _snackbarService.Show("Achievement Unlocked", $"{DGAchievements[AchievementIndex].Name} has been unlocked",
                         ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
                     DGAchievements[AchievementIndex].IsUnlockable = false;
-                    DGAchievements[AchievementIndex].ProgressState = "Achieved";
+                    DGAchievements[AchievementIndex].ProgressState = StringConstants.Achieved;
                     DGAchievements[AchievementIndex].DateUnlocked = DateTime.Now;
                     CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
                 }
@@ -628,9 +671,13 @@ namespace XAU.ViewModels.Pages
                         achievement.IsUnlockable = false;
                         achievement.ProgressState = StringConstants.Achieved;
                         achievement.DateUnlocked = unlocktime;
+                        achievement.VerifyState = "⏳";
                     }
                 }
                 CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+
+                // Verifica se o lote realmente aplicou e reporta quantas confirmaram.
+                _ = VerifyAndMarkBatchAsync(lockedAchievementIds, eventBased: false, announce: true);
             }
             catch (HttpRequestException hre)
             {
@@ -643,7 +690,6 @@ namespace XAU.ViewModels.Pages
         [RelayCommand]
         public async Task RefreshAchievements()
         {
-            // clears unlocked achievements from dictionary
             _unlockedAchievements.Clear();
 
             await LoadGameInfo();
@@ -654,33 +700,1011 @@ namespace XAU.ViewModels.Pages
         }
 
         [RelayCommand]
-        public void SearchAndFilterAchievements()
+        public async Task SearchAndFilterAchievements()
         {
-            ApplyAchievementFilter();
+            try
+            {
+                if (IsEventBased)
+                {
+                    string DataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU", "Events", "Data.json");
+                    var data = JObject.Parse(File.ReadAllText(DataPath));
+                    JArray SupportedGamesJ = (JArray)data["SupportedTitleIDs"];
+                    List<int> SupportedGames = SupportedGamesJ.ToObject<List<int>>();
+                    if (SupportedGames.Contains(int.Parse(TitleIDOverride)))
+                    {
+                        Unlockable = true;
+                        EventsData = (dynamic)data[TitleIDOverride];
+                    }
+                }
+
+                CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+
+                if (string.IsNullOrWhiteSpace(SearchText) && !IsFiltered)
+                {
+                    _snackbarService.Show("Error", $"Please Enter Query Text", ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+                    return;
+                }
+
+                DGAchievements.Clear();
+
+                if (string.IsNullOrWhiteSpace(SearchText) && IsFiltered)
+                {
+                    foreach (var achievement in Achievements)
+                    {
+                        var gamerscore = 0;
+                        if (achievement.rewards[0].type == StringConstants.Gamerscore)
+                        {
+                            gamerscore = int.Parse(achievement.rewards[0].value);
+                        }
+
+                        var dgAchievement = new DGAchievement()
+                        {
+                            Index = DGAchievements.Count,
+                            ID = int.Parse(achievement.id),
+                            Name = achievement.name,
+                            Description = achievement.description,
+                            IsSecret = achievement.isSecret,
+                            DateUnlocked = DateTime.Parse(achievement.progression.timeUnlocked),
+                            Gamerscore = gamerscore,
+                            RarityPercentage = float.Parse(achievement.raritycurrentPercentage, CultureInfo.InvariantCulture),
+                            RarityCategory = achievement.raritycurrentCategory,
+                            ProgressState = achievement.progressState,
+                            IsUnlockable = achievement.progressState != StringConstants.Achieved && Unlockable && !IsEventBased
+                        };
+
+                        // Sobrescreve com o estado de _unlockedAchievements, se existir.
+                        if (_unlockedAchievements.ContainsKey(dgAchievement.ID))
+                        {
+                            var unlocked = _unlockedAchievements[dgAchievement.ID];
+                            dgAchievement.IsUnlockable = unlocked.IsUnlockable;
+                            dgAchievement.ProgressState = unlocked.ProgressState;
+                            dgAchievement.DateUnlocked = unlocked.DateUnlocked;
+                        }
+
+                        DGAchievements.Add(dgAchievement);
+                    }
+
+                    if (IsEventBased && Unlockable)
+                    {
+                        foreach (var achievement in DGAchievements)
+                        {
+                            if (EventsData.Achievements.ContainsKey(achievement.ID.ToString()) && achievement.ProgressState != StringConstants.Achieved)
+                            {
+                                achievement.IsUnlockable = true;
+                            }
+                        }
+                        CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+                    }
+                    IsFiltered = false;
+                    return;
+                }
+
+                bool achievementsFound = false;
+
+                foreach (var achievement in Achievements)
+                {
+                    if (achievement.name.Contains(SearchText, StringComparison.OrdinalIgnoreCase) || achievement.description.Contains(SearchText, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var gamerscore = 0;
+                        if (achievement.rewards[0].type == StringConstants.Gamerscore)
+                        {
+                            gamerscore = int.Parse(achievement.rewards[0].value);
+                        }
+
+                        var dgAchievement = new DGAchievement()
+                        {
+                            Index = DGAchievements.Count,
+                            ID = int.Parse(achievement.id),
+                            Name = achievement.name,
+                            Description = achievement.description,
+                            IsSecret = achievement.isSecret,
+                            DateUnlocked = DateTime.Parse(achievement.progression.timeUnlocked),
+                            Gamerscore = gamerscore,
+                            RarityPercentage = float.Parse(achievement.raritycurrentPercentage, CultureInfo.InvariantCulture),
+                            RarityCategory = achievement.raritycurrentCategory,
+                            ProgressState = achievement.progressState,
+                            IsUnlockable = achievement.progressState != StringConstants.Achieved && Unlockable && !IsEventBased
+                        };
+
+                        // Sobrescreve com o estado de _unlockedAchievements, se existir.
+                        if (_unlockedAchievements.ContainsKey(dgAchievement.ID))
+                        {
+                            var unlockedAchievement = _unlockedAchievements[dgAchievement.ID];
+                            dgAchievement.IsUnlockable = unlockedAchievement.IsUnlockable;
+                            dgAchievement.ProgressState = unlockedAchievement.ProgressState;
+                            dgAchievement.DateUnlocked = unlockedAchievement.DateUnlocked;
+                        }
+
+                        DGAchievements.Add(dgAchievement);
+                        achievementsFound = true;
+                    }
+                }
+
+                if (!achievementsFound)
+                {
+                    _snackbarService.Show("Error", $"No Achievements Found", ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+                }
+
+                if (IsEventBased && Unlockable)
+                {
+                    foreach (var achievement in DGAchievements)
+                    {
+                        if (EventsData.Achievements.ContainsKey(achievement.ID.ToString()) && achievement.ProgressState != StringConstants.Achieved)
+                        {
+                            achievement.IsUnlockable = true;
+                        }
+                    }
+                    CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+                }
+
+                IsFiltered = true;
+            }
+            catch (Exception ex)
+            {
+                _snackbarService.Show("Error", "An error occurred while searching. Please try again.", ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+            }
+
+            await Task.CompletedTask;
         }
 
-        // Filtering is done purely through the ICollectionView predicate against the
-        // already-built DGAchievements collection. This avoids clearing/rebuilding the
-        // bound collection on every search (which previously re-parsed dates, re-read
-        // rewards and reallocated every row), so searches/sorts are effectively instant.
-        private void ApplyAchievementFilter()
-        {
-            var view = CollectionViewSource.GetDefaultView(DGAchievements);
+        #region Auto Unlocker
 
-            if (string.IsNullOrWhiteSpace(SearchText))
+        // Estado do painel do Auto Unlocker (ligado pela barra acima da grade).
+        [ObservableProperty] private bool _autoRunning = false;
+        [ObservableProperty] private bool _autoPaused = false;
+        [ObservableProperty] private bool _autoControlsEnabled = true;
+        [ObservableProperty] private bool _autoHasOrder = false;
+        [ObservableProperty] private string _autoStartPauseLabel = "Start";
+        [ObservableProperty] private string _autoCurrentAchievement = "";
+        [ObservableProperty] private string _autoCountdownText = "";
+        [ObservableProperty] private string _autoStatusText = "Idle";
+        [ObservableProperty] private double _autoProgressValue = 0;
+        [ObservableProperty] private string _autoEstimateText = "";
+        // Multiplicador de loop para conquistas de contador (padrão 1).
+        [ObservableProperty] private string _autoLoopCount = "1";
+
+        private CancellationTokenSource? _autoCts;
+        private readonly List<Task> _verifyTasks = new List<Task>();
+        private int _confirmedCount, _pendingCount, _failedCount;
+        private int _autoIndex, _autoTotal;
+        private string _autoFinalMessage = "";
+        private HashSet<string> _autoSkip = new HashSet<string>();
+
+        partial void OnAutoRunningChanged(bool value) => AutoControlsEnabled = !value;
+
+        // Botão único Start/Pause/Resume. Start dispara o run sem bloquear (o botão segue
+        // respondendo para pausar); durante a execução alterna pause/resume.
+        [RelayCommand]
+        public async Task ToggleAutoUnlocker()
+        {
+            if (AutoRunning)
             {
-                view.Filter = null;
+                AutoPaused = !AutoPaused;
+                AutoStartPauseLabel = AutoPaused ? "Resume" : "Pause";
                 return;
             }
 
-            var query = SearchText;
-            view.Filter = obj =>
+            if (!IsTitleIDValid || IsSelectedGame360)
             {
-                if (obj is not DGAchievement a)
-                    return false;
-                return (a.Name != null && a.Name.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0)
-                    || (a.Description != null && a.Description.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0);
-            };
+                _snackbarService.Show("Auto Unlocker", "Load a supported game first.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            if (!HomeViewModel.InitComplete)
+            {
+                _snackbarService.Show("Auto Unlocker", "Sign in before using this.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            if (IsEventBased && EventsToken == null)
+            {
+                ContentDialogResult tokenResult = await _contentDialogService.ShowSimpleDialogAsync(
+                    new SimpleContentDialogCreateOptions()
+                    {
+                        Title = "Error: You have not set an events token",
+                        Content = "To unlock event based games you must supply an events token. Please refer to the guide for more information.\nPressing the \"Open Guide\" button will open the documentation and guide in your default browser.",
+                        PrimaryButtonText = "Open Guide",
+                        CloseButtonText = "Close",
+                    });
+                if (tokenResult == ContentDialogResult.Primary)
+                {
+                    var sInfo = new System.Diagnostics.ProcessStartInfo(OpenableLinks.EventsDocumentationUrl)
+                    {
+                        UseShellExecute = true,
+                    };
+                    System.Diagnostics.Process.Start(sInfo);
+                }
+                return;
+            }
+
+            var order = OrderRepository.Load(TitleIDOverride);
+            if (order == null || order.Items.Count == 0)
+            {
+                _snackbarService.Show("Auto Unlocker", "No unlock order yet — press \"Get Unlock Order\" first.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+
+            // Fire-and-forget: retorna já e mantém o botão vivo para pause/resume. RunWithOrderAsync trata seus próprios erros.
+            _ = RunWithOrderAsync(order);
         }
+
+        // Botão "Get Unlock Order". Pede um gamertag de referência e (re)constrói a ordem
+        // a partir da timeline real de unlock desse jogador.
+        [RelayCommand]
+        public async Task GetUnlockOrder()
+        {
+            if (!IsTitleIDValid || IsSelectedGame360)
+            {
+                _snackbarService.Show("Auto Unlocker", "Load a supported game first.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            if (!HomeViewModel.InitComplete)
+            {
+                _snackbarService.Show("Auto Unlocker", "Sign in before using this.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            if (AutoRunning)
+            {
+                _snackbarService.Show("Auto Unlocker", "Stop the unlocker before changing the order.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+
+            if (OrderRepository.Exists(TitleIDOverride))
+            {
+                var replace = await _contentDialogService.ShowSimpleDialogAsync(new SimpleContentDialogCreateOptions()
+                {
+                    Title = "Replace existing order?",
+                    Content = "An unlock order already exists for this game. Generating a new one will replace it (delays you edited will be lost).",
+                    PrimaryButtonText = "Replace",
+                    CloseButtonText = "Keep current"
+                });
+                if (replace != ContentDialogResult.Primary)
+                    return;
+            }
+
+            var gamertag = await AskReferenceGamertagAsync();
+            if (string.IsNullOrWhiteSpace(gamertag))
+                return;
+
+            try
+            {
+                var alreadyEarned = new HashSet<string>(
+                    DGAchievements.Where(a => a.ProgressState == StringConstants.Achieved)
+                                  .Select(a => a.ID.ToString()));
+                var order = await OrderRepository.GenerateFromReferenceAsync(
+                    _xboxRestAPI.Value, TitleIDOverride, GameName, gamertag, alreadyEarned);
+                OrderRepository.Save(order);
+
+                // Jogos de evento: marca itens sem event data e oferece pular.
+                if (IsEventBased)
+                {
+                    var noData = order.Items.Where(it => !HasEventData(it.Id)).Select(it => it.Id).ToList();
+                    if (noData.Count > 0)
+                    {
+                        var ask = await _contentDialogService.ShowSimpleDialogAsync(new SimpleContentDialogCreateOptions()
+                        {
+                            Title = "Some achievements have no event data",
+                            Content = $"{noData.Count} of {order.Items.Count} achievements in this order have no event data and likely won't unlock. Skip them?",
+                            PrimaryButtonText = "Skip them",
+                            CloseButtonText = "Keep them"
+                        });
+                        if (ask == ContentDialogResult.Primary)
+                        {
+                            var skip = OrderRepository.LoadSkip(TitleIDOverride);
+                            foreach (var id in noData)
+                                skip.Add(id);
+                            OrderRepository.SaveSkip(TitleIDOverride, skip);
+                        }
+                    }
+                }
+
+                AutoHasOrder = true;
+                AutoStatusText = $"Order ready — {order.Items.Count} achievements";
+                _snackbarService.Show("Order created", $"{order.Items.Count} achievements queued. Press Start to begin.",
+                    ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
+            }
+            catch (Exception ex)
+            {
+                _snackbarService.Show("Could not create the order", ex.Message,
+                    ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+            }
+        }
+
+        // Confirma um lote de unlocks recém-enviados contra o serviço de conquistas e
+        // marca cada linha "✓" quando lê Achieved. Roda em segundo plano; nunca lança.
+        private async Task VerifyAndMarkBatchAsync(List<string> ids, bool eventBased, bool announce)
+        {
+            if (ids == null || ids.Count == 0)
+                return;
+
+            var pending = new HashSet<string>(ids);
+            var deadline = DateTime.UtcNow + (eventBased ? TimeSpan.FromMinutes(3) : TimeSpan.FromSeconds(45));
+            int[] backoff = { 3, 5, 8, 13, 21, 30 };
+            int attempt = 0;
+
+            while (pending.Count > 0 && DateTime.UtcNow < deadline)
+            {
+                var wait = backoff[Math.Min(attempt, backoff.Length - 1)];
+                attempt++;
+                try { await Task.Delay(TimeSpan.FromSeconds(wait)); } catch { break; }
+
+                AchievementsResponse? resp = null;
+                try
+                {
+                    await XboxRateLimiter.Achievements.WaitAsync(CancellationToken.None);
+                    resp = await _xboxRestAPI.Value.GetAchievementsForTitleAsync(HomeViewModel.XUIDOnly, TitleIDOverride);
+                }
+                catch { continue; }
+
+                var achieved = new HashSet<string>(
+                    resp?.achievements?.Where(a => a.progressState == StringConstants.Achieved).Select(a => a.id)
+                    ?? Enumerable.Empty<string>());
+
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    foreach (var id in pending.ToList())
+                    {
+                        if (achieved.Contains(id))
+                        {
+                            var a = DGAchievements.FirstOrDefault(x => x.ID.ToString() == id);
+                            if (a != null) a.VerifyState = "✓";
+                            pending.Remove(id);
+                        }
+                    }
+                    CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+                });
+            }
+
+            if (!announce)
+                return;
+            int confirmed = ids.Count - pending.Count;
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                if (pending.Count == 0)
+                    _snackbarService.Show("Verified", $"{confirmed} achievement(s) confirmed unlocked.",
+                        ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
+                else
+                    _snackbarService.Show("Partly confirmed",
+                        $"{confirmed} of {ids.Count} confirmed; {pending.Count} still pending (Xbox may still be processing).",
+                        ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+            });
+        }
+
+        // Indica se a conquista tem event data utilizável. Jogos comuns sempre "têm";
+        // jogos de evento checam a entrada no template Data.json.
+        private bool HasEventData(string id)
+        {
+            if (!IsEventBased)
+                return true;
+            var node = EventsData as JObject;
+            var achs = node?["Achievements"] as JObject;
+            return achs != null && achs[id] != null;
+        }
+
+        private string ComposeAutoStatus()
+        {
+            var status = $"{_autoIndex}/{_autoTotal}  •  ✓ {_confirmedCount}";
+            if (_pendingCount > 0) status += $"  ⏳ {_pendingCount}";
+            if (_failedCount > 0) status += $"  ✗ {_failedCount}";
+            return status;
+        }
+
+        // Botão "Edit Skip List". Lista as conquistas da ordem com checkboxes
+        // (marcado = incluir, desmarcado = pular) e salva os desmarcados na skip list.
+        [RelayCommand]
+        public async Task EditSkipList()
+        {
+            if (AutoRunning)
+            {
+                _snackbarService.Show("Auto Unlocker", "Stop the unlocker before editing the skip list.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            await EditSkipListForTitleAsync(TitleIDOverride);
+        }
+
+        // Reutilizável pela fila: edita a skip list de um título específico.
+        public async Task EditSkipListForTitleAsync(string titleId)
+        {
+            var order = OrderRepository.Load(titleId);
+            if (order == null || order.Items.Count == 0)
+            {
+                _snackbarService.Show("Auto Unlocker", "No unlock order yet for this game.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+
+            var skip = OrderRepository.LoadSkip(titleId);
+
+            var header = new System.Windows.Controls.TextBlock
+            {
+                FontWeight = FontWeights.Bold,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+
+            var boxes = new List<(System.Windows.Controls.CheckBox cb, UnlockOrderItem item)>();
+            var list = new System.Windows.Controls.StackPanel();
+            foreach (var item in order.Items)
+            {
+                var cb = new System.Windows.Controls.CheckBox
+                {
+                    Content = $"{item.Name}  —  {FormatTime(item.DelaySeconds)}  •  {item.Gamerscore}G",
+                    IsChecked = !skip.Contains(item.Id),
+                    Margin = new Thickness(0, 2, 0, 2)
+                };
+                boxes.Add((cb, item));
+                list.Children.Add(cb);
+            }
+
+            void UpdateSummary()
+            {
+                long seconds = 0;
+                int included = 0;
+                foreach (var (cb, item) in boxes)
+                {
+                    if (cb.IsChecked == true)
+                    {
+                        included++;
+                        seconds += item.DelaySeconds;
+                    }
+                }
+                header.Text = $"{included} of {order.Items.Count} included  •  estimated time {FormatTime(seconds)}";
+            }
+            foreach (var (cb, _) in boxes)
+            {
+                cb.Checked += (_, _) => UpdateSummary();
+                cb.Unchecked += (_, _) => UpdateSummary();
+            }
+            UpdateSummary();
+
+            var scroll = new System.Windows.Controls.ScrollViewer
+            {
+                Content = list,
+                MaxHeight = 320,
+                VerticalScrollBarVisibility = System.Windows.Controls.ScrollBarVisibility.Auto
+            };
+            var panel = new System.Windows.Controls.StackPanel { MinWidth = 400 };
+            panel.Children.Add(header);
+            panel.Children.Add(scroll);
+
+            var result = await _contentDialogService.ShowSimpleDialogAsync(new SimpleContentDialogCreateOptions()
+            {
+                Title = $"Skip List — {order.GameName}",
+                Content = panel,
+                PrimaryButtonText = "Save",
+                CloseButtonText = "Cancel"
+            });
+
+            if (result == ContentDialogResult.Primary)
+            {
+                var newSkip = new HashSet<string>();
+                foreach (var (cb, item) in boxes)
+                {
+                    if (cb.IsChecked != true)
+                        newSkip.Add(item.Id);
+                }
+                OrderRepository.SaveSkip(titleId, newSkip);
+                _snackbarService.Show("Skip list saved", $"{newSkip.Count} achievement(s) will be skipped.",
+                    ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
+            }
+        }
+
+        // Botão "Edit Delays". Permite ajustar a espera (em segundos) antes de cada
+        // unlock e salva de volta na ordem.
+        [RelayCommand]
+        public async Task EditDelays()
+        {
+            if (AutoRunning)
+            {
+                _snackbarService.Show("Auto Unlocker", "Stop the unlocker before editing delays.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            await EditDelaysForTitleAsync(TitleIDOverride);
+        }
+
+        // Reutilizável pela fila: edita os delays de um título específico.
+        public async Task EditDelaysForTitleAsync(string titleId)
+        {
+            var order = OrderRepository.Load(titleId);
+            if (order == null || order.Items.Count == 0)
+            {
+                _snackbarService.Show("Auto Unlocker", "No unlock order yet for this game.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+
+            var hint = new System.Windows.Controls.TextBlock
+            {
+                Text = "Delay (in seconds) to wait before each achievement unlocks. The first is usually 0.",
+                TextWrapping = TextWrapping.Wrap,
+                Opacity = 0.8,
+                Margin = new Thickness(0, 0, 0, 10)
+            };
+
+            var rows = new List<(System.Windows.Controls.TextBox box, UnlockOrderItem item)>();
+            var list = new System.Windows.Controls.StackPanel();
+            foreach (var item in order.Items)
+            {
+                var row = new System.Windows.Controls.Grid { Margin = new Thickness(0, 2, 0, 2) };
+                row.ColumnDefinitions.Add(new System.Windows.Controls.ColumnDefinition { Width = new System.Windows.GridLength(1, System.Windows.GridUnitType.Star) });
+                row.ColumnDefinitions.Add(new System.Windows.Controls.ColumnDefinition { Width = new System.Windows.GridLength(90) });
+
+                var label = new System.Windows.Controls.TextBlock
+                {
+                    Text = item.Name,
+                    TextTrimming = System.Windows.TextTrimming.CharacterEllipsis,
+                    VerticalAlignment = System.Windows.VerticalAlignment.Center,
+                    Margin = new Thickness(0, 0, 8, 0)
+                };
+                System.Windows.Controls.Grid.SetColumn(label, 0);
+
+                var box = new System.Windows.Controls.TextBox
+                {
+                    Text = item.DelaySeconds.ToString(),
+                    TextAlignment = System.Windows.TextAlignment.Right,
+                    VerticalAlignment = System.Windows.VerticalAlignment.Center
+                };
+                System.Windows.Controls.Grid.SetColumn(box, 1);
+
+                row.Children.Add(label);
+                row.Children.Add(box);
+                list.Children.Add(row);
+                rows.Add((box, item));
+            }
+
+            var scroll = new System.Windows.Controls.ScrollViewer
+            {
+                Content = list,
+                MaxHeight = 320,
+                VerticalScrollBarVisibility = System.Windows.Controls.ScrollBarVisibility.Auto
+            };
+            var panel = new System.Windows.Controls.StackPanel { MinWidth = 420 };
+            panel.Children.Add(hint);
+            panel.Children.Add(scroll);
+
+            var result = await _contentDialogService.ShowSimpleDialogAsync(new SimpleContentDialogCreateOptions()
+            {
+                Title = $"Edit Delays — {order.GameName}",
+                Content = panel,
+                PrimaryButtonText = "Save",
+                CloseButtonText = "Cancel"
+            });
+
+            if (result == ContentDialogResult.Primary)
+            {
+                foreach (var (box, item) in rows)
+                {
+                    if (long.TryParse(box.Text?.Trim(), out var seconds) && seconds >= 0)
+                        item.DelaySeconds = seconds;
+                }
+                OrderRepository.Save(order);
+                _snackbarService.Show("Delays saved", $"Total run time ~{FormatTime(order.TotalDurationSeconds)}.",
+                    ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
+            }
+        }
+
+        // Ao abrir um jogo com unlock em andamento, oferece continuar.
+        private async Task CheckResumeAsync()
+        {
+            if (!IsTitleIDValid || IsSelectedGame360)
+                return;
+            // Só perguntamos uma vez por jogo nesta sessão.
+            if (_resumePrompted.Contains(TitleIDOverride))
+                return;
+            // Precisa existir ordem salva E um estado em andamento.
+            if (!OrderRepository.Exists(TitleIDOverride) || OrderRepository.LoadState(TitleIDOverride) == null)
+                return;
+            // Jogo de evento sem token válido: não dá para retomar agora.
+            if (IsEventBased && EventsToken == null)
+                return;
+
+            _resumePrompted.Add(TitleIDOverride);
+
+            var answer = await _contentDialogService.ShowSimpleDialogAsync(new SimpleContentDialogCreateOptions()
+            {
+                Title = "Continue unlock?",
+                Content = $"There is an automatic unlock in progress for \"{GameName}\". Continue from where it stopped?",
+                PrimaryButtonText = "Continue",
+                CloseButtonText = "Not now"
+            });
+
+            if (answer == ContentDialogResult.Primary)
+            {
+                var order = OrderRepository.Load(TitleIDOverride);
+                if (order != null && order.Items.Count > 0)
+                    _ = RunWithOrderAsync(order); // controlado pelo painel; não bloqueia a navegação
+            }
+        }
+
+        // Mostra um diálogo pedindo o gamertag de referência. Retorna o texto ou null se cancelar.
+        private async Task<string?> AskReferenceGamertagAsync()
+        {
+            var box = new Wpf.Ui.Controls.TextBox
+            {
+                PlaceholderText = "Enter the gamertag",
+                MinWidth = 300
+            };
+            var panel = new System.Windows.Controls.StackPanel();
+            panel.Children.Add(new System.Windows.Controls.TextBlock
+            {
+                Text = "Enter the gamertag of a player who has already completed this game. The order will copy their real unlock times so it looks natural.",
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+            panel.Children.Add(box);
+
+            var result = await _contentDialogService.ShowSimpleDialogAsync(new SimpleContentDialogCreateOptions()
+            {
+                Title = "Create Unlock Order",
+                Content = panel,
+                PrimaryButtonText = "Generate",
+                CloseButtonText = "Cancel"
+            });
+
+            return result == ContentDialogResult.Primary ? box.Text?.Trim() : null;
+        }
+
+        // Botão "Stop" (visível só durante a execução). Cancela o run; o estado salvo
+        // permite retomar depois.
+        [RelayCommand]
+        public void StopAutoUnlocker()
+        {
+            _autoCts?.Cancel();
+            AutoPaused = false;
+            AutoStartPauseLabel = "Start";
+            AutoCountdownText = "Stopping...";
+        }
+
+        // Executa a ordem e alimenta o painel acima da grade. Não bloqueia: o motor roda
+        // em segundo plano, o painel reflete o progresso ao vivo e cada unlock é
+        // verificado em background mantendo o ritmo natural enquanto ✓/⏳ se preenchem.
+        private RtaAchievementStream? _autoRta;
+        private CancellationTokenSource? _spoofCts;
+        private Task? _spoofPing;
+
+        // Mantém a presença do jogo spoofado viva durante toda a execução reenviando o
+        // heartbeat a cada 5 minutos (a mesma chamada do Auto Spoofer).
+        private async Task SpoofPingLoopAsync(string titleId, CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try { await Task.Delay(TimeSpan.FromMinutes(5), token); }
+                catch (OperationCanceledException) { return; }
+                try { await _xboxRestAPI.Value.SendHeartbeatAsync(HomeViewModel.XUIDOnly, titleId); }
+                catch { /* best-effort; o próximo ping tenta de novo */ }
+            }
+        }
+
+        private async Task RunWithOrderAsync(UnlockOrder order, CancellationToken externalToken = default)
+        {
+            if (AutoRunning)
+                return;
+
+            // Liga o cancelamento externo (fila) ao cancelamento interno do run.
+            _autoCts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
+            _verifyTasks.Clear();
+            _confirmedCount = _pendingCount = _failedCount = 0;
+            _autoIndex = 0;
+            _autoTotal = order.Items.Count;
+            _autoFinalMessage = "";
+            _autoSkip = OrderRepository.LoadSkip(TitleIDOverride);
+
+            AutoRunning = true;
+            AutoPaused = false;
+            AutoStartPauseLabel = "Pause";
+            AutoCurrentAchievement = "";
+            AutoCountdownText = "Starting...";
+            AutoProgressValue = 0;
+            AutoStatusText = ComposeAutoStatus();
+
+            // Itens que o motor pula direto: já obtidos + skip list.
+            var alreadyUnlocked = new HashSet<string>(
+                DGAchievements.Where(a => a.ProgressState == StringConstants.Achieved)
+                              .Select(a => a.ID.ToString()));
+            alreadyUnlocked.UnionWith(_autoSkip);
+
+            // Stream RTA best-effort para acelerar a verificação (fail-open: null = só polling).
+            var scid = AchievementResponse?.achievements?.FirstOrDefault()?.serviceConfigId ?? "";
+            try
+            {
+                _autoRta = await RtaAchievementStream.TryStartAsync(
+                    HomeViewModel.XAUTH, HomeViewModel.XUIDOnly, scid, _autoCts.Token);
+            }
+            catch { _autoRta = null; }
+
+            // Mantém a presença no título durante todo o run: spoof agora, depois ping a
+            // cada 5 min (CTS próprio para a verificação não ser cortada no stop).
+            _spoofCts = new CancellationTokenSource();
+            try { await _xboxRestAPI.Value.SendHeartbeatAsync(HomeViewModel.XUIDOnly, TitleIDOverride); }
+            catch { /* best-effort */ }
+            _spoofPing = SpoofPingLoopAsync(TitleIDOverride, _spoofCts.Token);
+
+            // Callback de progresso do motor -> painel (thread de UI).
+            Action<AutoProgress> report = progress => Application.Current.Dispatcher.Invoke(() =>
+            {
+                _autoIndex = progress.Index;
+                _autoTotal = progress.Total;
+                AutoCurrentAchievement = progress.AchievementName ?? "";
+
+                if (!string.IsNullOrEmpty(progress.Message) && progress.Message != "Unlocking")
+                    AutoCountdownText = progress.Message;
+                else if (progress.SecondsRemaining >= 0)
+                    AutoCountdownText = $"Next in {FormatTime(progress.SecondsRemaining)}";
+                else
+                    AutoCountdownText = "Unlocking...";
+
+                AutoProgressValue = progress.Total > 0 ? (double)progress.Index / progress.Total : 0;
+                AutoStatusText = ComposeAutoStatus();
+
+                // Fim estimado = countdown atual + delays dos itens restantes (ignorando a skip list).
+                long remaining = progress.SecondsRemaining > 0 ? progress.SecondsRemaining : 0;
+                for (int k = progress.Index; k < order.Items.Count; k++)
+                    if (!_autoSkip.Contains(order.Items[k].Id))
+                        remaining += order.Items[k].DelaySeconds;
+                AutoEstimateText = (!progress.Completed && remaining > 0)
+                    ? $"Est. finish ~{DateTime.Now.AddSeconds(remaining):HH:mm}"
+                    : "";
+
+                if (progress.Completed)
+                    _autoFinalMessage = progress.Message;
+            });
+
+            var engine = new XAU.Services.AutoUnlock.AutoUnlocker(TitleIDOverride);
+            try
+            {
+                await Task.Run(() => engine.RunAsync(
+                    order, UnlockItemAsync, alreadyUnlocked, report, () => AutoPaused, _autoCts.Token));
+            }
+            catch { /* o motor é seguro a cancelamento; defensivo */ }
+
+            // Deixa as verificações em background pendentes terminarem (ou cancelarem).
+            try { await Task.WhenAll(_verifyTasks.ToArray()); } catch { }
+
+            // Para o spoof ping (token separado do run/verify).
+            _spoofCts?.Cancel();
+            try { if (_spoofPing != null) await _spoofPing; } catch { }
+            _spoofCts?.Dispose();
+            _spoofCts = null;
+            _spoofPing = null;
+
+            // Desmonta RTA + estado do run.
+            _autoRta?.Dispose();
+            _autoRta = null;
+            _autoCts?.Dispose();
+            _autoCts = null;
+
+            AutoRunning = false;
+            AutoPaused = false;
+            AutoStartPauseLabel = "Start";
+            AutoCurrentAchievement = "";
+            AutoCountdownText = "";
+            AutoEstimateText = "";
+            AutoStatusText = ComposeAutoStatus();
+
+            // Resumo final.
+            if (_autoFinalMessage == "Completed")
+                _snackbarService.Show("Auto Unlocker",
+                    $"Done — ✓ {_confirmedCount} confirmed" + (_pendingCount > 0 ? $", ⏳ {_pendingCount} still pending" : "") + ".",
+                    ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
+            else if (!string.IsNullOrEmpty(_autoFinalMessage) && _autoFinalMessage.StartsWith("Failed"))
+                _snackbarService.Show("Auto Unlocker", _autoFinalMessage,
+                    ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+            else
+                _snackbarService.Show("Auto Unlocker", "Stopped — it will continue from where it stopped next time.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+        }
+
+        // Ponto de entrada da fila: roda um título do começo ao fim reaproveitando todo o
+        // motor do auto unlocker (ordem, RTA, verificação). Gera a ordem pelo gamertag de
+        // referência se ainda não existir. Retorna true quando concluiu por completo.
+        public async Task<QueueRunResult> RunQueuedTitleAsync(string titleId, string gamertag, CancellationToken ct)
+        {
+            if (AutoRunning) return QueueRunResult.Invalid;
+
+            TitleIDOverride = titleId;
+            TitleID = "0";
+            await LoadGameInfo();
+            if (!IsTitleIDValid || IsSelectedGame360) return QueueRunResult.Invalid;
+            await LoadAchievements();
+
+            // Já 100%? marca como concluído sem rodar nada.
+            if (DGAchievements.Count > 0 && DGAchievements.All(a => a.ProgressState == StringConstants.Achieved))
+                return QueueRunResult.AlreadyComplete;
+
+            var order = OrderRepository.Load(titleId);
+            if (order == null || order.Items.Count == 0)
+            {
+                if (string.IsNullOrWhiteSpace(gamertag)) return QueueRunResult.Invalid;
+                var earned = new HashSet<string>(
+                    DGAchievements.Where(a => a.ProgressState == StringConstants.Achieved)
+                                  .Select(a => a.ID.ToString()));
+                try
+                {
+                    order = await OrderRepository.GenerateFromReferenceAsync(
+                        _xboxRestAPI.Value, titleId, GameName, gamertag, earned);
+                    OrderRepository.Save(order);
+                }
+                catch { return QueueRunResult.Failed; }
+            }
+            if (order.Items.Count == 0) return QueueRunResult.AlreadyComplete;
+
+            await RunWithOrderAsync(order, ct);
+            return _autoFinalMessage == "Completed" ? QueueRunResult.Completed : QueueRunResult.Failed;
+        }
+
+        // Botão "Add to Queue" da tela de Achievements: enfileira o jogo aberto agora.
+        // Precisa de uma ordem já gerada (o usuário cria com "Get Unlock Order").
+        [RelayCommand]
+        public void AddToQueue()
+        {
+            if (!IsTitleIDValid || IsSelectedGame360)
+            {
+                _snackbarService.Show("Queue", "Load a supported game first.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            if (!OrderRepository.Exists(TitleIDOverride))
+            {
+                _snackbarService.Show("Queue", "Press \"Get Unlock Order\" first, then add it to the queue.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            // Resolve a fila pelo container (evita dependência circular no construtor).
+            XAU.App.GetService<QueueViewModel>()?.AddGameDirect(TitleIDOverride, GameName);
+        }
+
+        // Checagem barata em memória: a conquista tem requisito de contador (target > 1)?
+        // Usa o AchievementResponse já carregado, então não-contadores não pagam leitura extra.
+        private bool LooksLikeCounter(string id)
+        {
+            var ach = AchievementResponse?.achievements?.FirstOrDefault(a => a.id == id);
+            var req = ach?.progression?.requirements?
+                .FirstOrDefault(r => long.TryParse(r.target, out var t) && t > 1);
+            return req != null;
+        }
+
+        // Envia o unlock de um item da ordem. Retorna true se o ENVIO deu certo para o
+        // motor manter o ritmo; a aplicação real é confirmada em background por
+        // VerifyAndMarkAsync (200 não é prova — OneCollector retorna 200 mesmo em falha silenciosa).
+        private async Task<bool> UnlockItemAsync(UnlockOrderItem item)
+        {
+            bool eventBased = IsEventBased;
+            var token = _autoCts?.Token ?? CancellationToken.None;
+
+            // Caminho de contador: para conquistas de evento que parecem contador
+            // (target > 1), sonda + mede + completa até o alvo. Faz a própria verificação,
+            // então marca a linha inline e pula o verify em background.
+            if (eventBased && LooksLikeCounter(item.Id))
+            {
+                CounterResult counter;
+                try
+                {
+                    var cu = new CounterUnlocker(_xboxRestAPI.Value, TitleIDOverride, HomeViewModel.XUIDOnly, EventsToken);
+                    counter = await cu.RunAsync(item.Id, (JObject)EventsData, token);
+                }
+                catch { counter = CounterResult.Failed; }
+
+                if (counter == CounterResult.Failed)
+                    return false;
+
+                if (counter != CounterResult.NotCounter)
+                {
+                    Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        var a = DGAchievements.FirstOrDefault(x => x.ID.ToString() == item.Id);
+                        if (a != null) a.IsUnlockable = false;
+                        if (counter == CounterResult.Achieved)
+                        {
+                            _confirmedCount++;
+                            if (a != null) { a.ProgressState = StringConstants.Achieved; a.DateUnlocked = DateTime.Now; a.VerifyState = "✓"; }
+                        }
+                        else
+                        {
+                            _pendingCount++;
+                            if (a != null) a.VerifyState = "⏳";
+                        }
+                        AutoStatusText = ComposeAutoStatus();
+                        CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+                    });
+                    return true;
+                }
+                // counter == NotCounter -> cai no event unlock normal.
+            }
+
+            try
+            {
+                if (eventBased)
+                {
+                    int multiplier = int.TryParse(AutoLoopCount?.Trim(), out var m) && m > 0 ? m : 1;
+                    var eventUnlocker = new EventUnlocker(
+                        _xboxRestAPI.Value, TitleIDOverride, HomeViewModel.XUIDOnly, EventsToken);
+                    await eventUnlocker.UnlockAsync(item.Id, (JObject)EventsData, multiplier);
+                }
+                else
+                {
+                    // (UnlockTitleBasedAchievementsAsync aplica rate limit internamente.)
+                    await _xboxRestAPI.Value.UnlockTitleBasedAchievementAsync(
+                        AchievementResponse.achievements[0].serviceConfigId,
+                        AchievementResponse.achievements[0].titleAssociations[0].id,
+                        HomeViewModel.XUIDOnly, item.Id);
+                }
+            }
+            catch
+            {
+                return false; // envio falhou -> motor para
+            }
+
+            // UI otimista: marca como Achieved já (igual ao unlock manual) com "⏳".
+            // A verificação em background promove para "✓"; nunca reverte o Achieved.
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                var targetAch = DGAchievements.FirstOrDefault(a => a.ID.ToString() == item.Id);
+                if (targetAch != null)
+                {
+                    targetAch.IsUnlockable = false;
+                    targetAch.ProgressState = StringConstants.Achieved;
+                    targetAch.DateUnlocked = DateTime.Now;
+                    targetAch.VerifyState = "⏳";
+                }
+                CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+            });
+
+            // Verifica em background para o cronograma manter o ritmo natural.
+            _verifyTasks.Add(VerifyAndMarkAsync(item, eventBased, token));
+            return true;
+        }
+
+        // Confirmação em background de um unlock via serviço de conquistas
+        // (acelerada por RTA quando disponível, senão por polling). Atualiza a linha e os contadores.
+        private async Task VerifyAndMarkAsync(UnlockOrderItem item, bool eventBased, CancellationToken token)
+        {
+            var verifier = new UnlockVerifier(_xboxRestAPI.Value, HomeViewModel.XUIDOnly, TitleIDOverride);
+            var outcome = await verifier.WaitForAchievedAsync(item.Id, eventBased, token, _autoRta);
+
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                var targetAch = DGAchievements.FirstOrDefault(a => a.ID.ToString() == item.Id);
+                switch (outcome)
+                {
+                    case VerifyOutcome.Confirmed:
+                        _confirmedCount++;
+                        if (targetAch != null)
+                        {
+                            targetAch.IsUnlockable = false;
+                            targetAch.ProgressState = StringConstants.Achieved;
+                            targetAch.DateUnlocked = DateTime.Now;
+                            targetAch.VerifyState = "✓";
+                        }
+                        break;
+                    case VerifyOutcome.Pending:
+                        _pendingCount++;
+                        if (targetAch != null)
+                            targetAch.VerifyState = "⏳";
+                        break;
+                    case VerifyOutcome.Cancelled:
+                        if (targetAch != null)
+                            targetAch.VerifyState = "⏳";
+                        break;
+                }
+                AutoStatusText = ComposeAutoStatus();
+                CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
+            });
+        }
+
+        // Formata segundos em HH:MM:SS (ou MM:SS quando não chega a uma hora).
+        private static string FormatTime(long seconds)
+        {
+            var h = seconds / 3600;
+            var m = (seconds % 3600) / 60;
+            var s = seconds % 60;
+            return h > 0 ? $"{h:00}:{m:00}:{s:00}" : $"{m:00}:{s:00}";
+        }
+
+        #endregion
     }
 }

--- a/XAU/ViewModels/Pages/HomeViewModel.cs
+++ b/XAU/ViewModels/Pages/HomeViewModel.cs
@@ -25,7 +25,6 @@ namespace XAU.ViewModels.Pages
         public static string ToolVersion = "EmptyDevToolVersion";
         public static string EventsVersion = "1.0";
 
-        //profile vars
         [ObservableProperty] private string? _gamerPic = "pack://application:,,,/Assets/cirno.png";
         [ObservableProperty] private string? _gamerTag = "Gamertag: Unknown   ";
         [ObservableProperty] private string? _xuid = "XUID: Unknown";
@@ -50,18 +49,18 @@ namespace XAU.ViewModels.Pages
         private readonly Lazy<GithubRestApi> _gitHubRestAPI = new Lazy<GithubRestApi>();
         private System.Windows.Threading.DispatcherTimer? _tokenRefreshTimer;
         private global::Windows.Security.Credentials.WebAccount? _currentWamAccount;
+        private string? _selectedGdkXuid;  // definido no login via cache do Gaming Services (GDK)
 
-        public static int SpoofingStatus = 0; //0 = NotSpoofing, 1 = Spoofing, 2 = AutoSpoofing
+        public static int SpoofingStatus = 0; // 0 = NotSpoofing, 1 = Spoofing, 2 = AutoSpoofing
         public static string SpoofedTitleID = "0";
         public static string AutoSpoofedTitleID = "0";
 
-        //SnackBar
         public HomeViewModel(ISnackbarService snackbarService, IContentDialogService contentDialogService)
         {
             _snackbarService = snackbarService;
             _contentDialogService = contentDialogService;
 
-            // Assume XAUTH and System Language are set by the time this is actually instantiated
+            // Assume que XAUTH e o idioma do sistema já estão definidos quando isto é instanciado
             _xboxRestAPI = new Lazy<XboxRestAPI>(() => new XboxRestAPI(XAUTH));
         }
         private readonly ISnackbarService _snackbarService;
@@ -81,7 +80,7 @@ namespace XAU.ViewModels.Pages
         string SettingsFilePath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU"), "settings.json");
         string EventsMetaFilePath = Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU"), "Events", "meta.json");
 
-        // WAM accounts (loaded on startup, selected via popup)
+        // Contas WAM (carregadas na inicialização, escolhidas via popup)
         private List<global::Windows.Security.Credentials.WebAccount> _wamAccounts = new();
 
         public async void OnNavigatedTo()
@@ -97,10 +96,9 @@ namespace XAU.ViewModels.Pages
             if (ToolVersion == "EmptyDevToolVersion")
                 return;
 
-            // Pre-release builds report "PRE-<commit>"; anything else is treated as a
-            // standard release. Pre-releases are looked up via the prerelease list, while
-            // standard builds use /releases/latest (which EXCLUDES pre-releases, so users
-            // on a standard release are never offered a pre-release build).
+            // Builds pre-release reportam "PRE-<commit>"; o resto é release padrão.
+            // Pre-releases buscam na lista de prereleases; builds padrão usam /releases/latest
+            // (que EXCLUI pre-releases, então quem está num release padrão nunca recebe um pre-release).
             var isPreRelease = ToolVersion.StartsWith("PRE-");
 
             try
@@ -250,7 +248,6 @@ namespace XAU.ViewModels.Pages
             }
             ZipFile.ExtractToDirectory(zipFilePath, extractPath);
             File.Delete(zipFilePath);
-            //download and place meta.json in the events folder
             string MetaFilePath = Path.Combine(eventsFolderPath, "meta.json");
             using (var client = new FileDownloader())
             {
@@ -380,62 +377,69 @@ namespace XAU.ViewModels.Pages
         [RelayCommand]
         private async Task LoginWithWam()
         {
+            // Caminho preferido: a identidade enrolled em cache do Gaming Services no disco
+            // (compartilhada por Microsoft Store, app Xbox e jogos GDK). Só esse token é
+            // device-enrolled, então só ele faz spoof de presença e desbloqueia title-based.
+            // O picker vem desse cache, logo toda conta listada é spoof-capable. Sem WAM, sem popup.
+            if (XAU.Services.GdkTokenService.CacheExists)
+            {
+                var accounts = XAU.Services.GdkTokenService.GetXboxLiveTokens();
+                if (accounts.Count == 0)
+                {
+                    await _contentDialogService.ShowSimpleDialogAsync(
+                        new SimpleContentDialogCreateOptions()
+                        {
+                            Title = "No Xbox account found",
+                            Content = "Sign in to the account you want to use in the Microsoft Store or Xbox app, then try again.",
+                            CloseButtonText = "OK"
+                        });
+                    return;
+                }
+
+                XAU.Services.GdkTokenService.XToken sel;
+                if (accounts.Count == 1)
+                {
+                    sel = accounts[0];
+                }
+                else
+                {
+                    var idx = await ShowAccountPickerAsync("Select an account",
+                        accounts.Select(a => string.IsNullOrEmpty(a.Gamertag) ? a.Xuid : a.Gamertag).ToList());
+                    if (idx < 0) return;
+                    sel = accounts[idx];
+                }
+
+                LoginText = "Logging in...";
+                await ApplyGdkLoginAsync(sel);
+                StartTokenRefreshTimer();
+                GrabProfile();
+                return;
+            }
+
+            // Fallback: sem cache do Gaming Services → WAM. Leitura/perfil/eventos funcionam,
+            // mas spoof de presença e unlocks title-based NÃO (o token não é enrolled).
             if (_wamAccounts.Count == 0)
             {
                 await _contentDialogService.ShowSimpleDialogAsync(
                     new SimpleContentDialogCreateOptions()
                     {
                         Title = "No accounts found",
-                        Content = "You need at least one Microsoft account signed in to Windows.\n\nGo to Settings > Accounts > Email & accounts to add one.",
+                        Content = "Sign in to the Microsoft Store / Xbox app, or add a Microsoft account in Windows (Settings > Accounts > Email & accounts).",
                         CloseButtonText = "OK"
                     });
                 return;
             }
 
-            global::Windows.Security.Credentials.WebAccount? selected;
-
+            global::Windows.Security.Credentials.WebAccount selected;
             if (_wamAccounts.Count == 1)
             {
                 selected = _wamAccounts[0];
             }
             else
             {
-                var itemContainerStyle = new Style(typeof(System.Windows.Controls.ListBoxItem));
-                itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.PaddingProperty, new Thickness(8, 6, 8, 6)));
-                itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.MarginProperty, new Thickness(0, 2, 0, 2)));
-                itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BorderThicknessProperty, new Thickness(1)));
-                itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BorderBrushProperty, System.Windows.Media.Brushes.Transparent));
-                itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.CursorProperty, System.Windows.Input.Cursors.Hand));
-                var hoverTrigger = new Trigger { Property = System.Windows.Controls.ListBoxItem.IsMouseOverProperty, Value = true };
-                hoverTrigger.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BackgroundProperty,
-                    new SolidColorBrush(System.Windows.Media.Color.FromArgb(0x20, 0x60, 0xCD, 0xFF))));
-                hoverTrigger.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BorderBrushProperty,
-                    new SolidColorBrush(System.Windows.Media.Color.FromArgb(0x40, 0x60, 0xCD, 0xFF))));
-                itemContainerStyle.Triggers.Add(hoverTrigger);
-
-                var listBox = new ListBox
-                {
-                    ItemsSource = _wamAccounts.Select(a => a.UserName).ToList(),
-                    ItemContainerStyle = itemContainerStyle,
-                    BorderThickness = new Thickness(0),
-                    Background = System.Windows.Media.Brushes.Transparent
-                };
-
-                var result = await _contentDialogService.ShowSimpleDialogAsync(
-                    new SimpleContentDialogCreateOptions()
-                    {
-                        Title = "Select an account",
-                        Content = new System.Windows.Controls.ScrollViewer
-                        {
-                            MaxHeight = 300,
-                            Content = listBox
-                        },
-                        PrimaryButtonText = "Select",
-                        CloseButtonText = "Cancel"
-                    });
-                if (result != ContentDialogResult.Primary || listBox.SelectedIndex < 0)
-                    return;
-                selected = _wamAccounts[listBox.SelectedIndex];
+                var idx = await ShowAccountPickerAsync("Select an account", _wamAccounts.Select(a => a.UserName).ToList());
+                if (idx < 0) return;
+                selected = _wamAccounts[idx];
             }
 
             LoginText = "Logging in...";
@@ -447,6 +451,7 @@ namespace XAU.ViewModels.Pages
                 XAUTH = XAU.Services.WamAuthService.GetXblToken()!;
                 XUIDOnly = XAU.Services.WamAuthService.Xuid!;
                 AchievementsViewModel.EventsToken = XAU.Services.WamAuthService.GetEventsToken();
+                _xboxRestAPI = new Lazy<XboxRestAPI>(() => new XboxRestAPI(XAUTH));
                 InitComplete = true;
                 IsLoggedIn = true;
                 LoginText = "Logged In";
@@ -458,6 +463,101 @@ namespace XAU.ViewModels.Pages
                 LoginText = "Login";
                 _snackbarService.Show("Login", "Authentication failed. Make sure the account is signed in to Windows.", ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
             }
+        }
+
+        // Aplica uma conta do Gaming Services (GDK): xauth enrolled lido do disco + events
+        // token mintado do user token em cache da mesma conta. Usado no login e no timer de
+        // refresh (tudo relê do disco, sem popup).
+        private async Task ApplyGdkLoginAsync(XAU.Services.GdkTokenService.XToken sel)
+        {
+            // Events token: prefere WAM (device-bound, carrega a claim de xuid — é o que
+            // realmente CREDITA unlocks event-based). O mint do Gaming Services é aceito pela
+            // telemetria mas não tem a claim, então só ingere, nunca credita. Cai no mint
+            // quando a conta não é do Windows (só Store, não adicionada ao Windows).
+            string? eventsToken = await TryGetWamEventsTokenAsync(sel.Xuid);
+            var eventsSource = eventsToken != null ? "wam" : "none";
+            if (eventsToken == null)
+            {
+                try
+                {
+                    eventsToken = await XAU.Services.GdkTokenService.MintEventsTokenAsync(sel.Xuid, sel.Uhs);
+                    if (eventsToken != null) eventsSource = "gdk-mint (may not credit unlocks)";
+                }
+                catch (Exception ex) { EventsLog($"events mint failed: {ex.Message}"); }
+            }
+
+            // xauth = o token enrolled do Gaming Services (spoof + unlocks title-based).
+            // SetExternalToken sobrescreve só xauth/xuid/uhs; o events token WAM em cache acima
+            // continua intacto, e a assinatura PoP fica desligada (o token GDK não é PoP-bound).
+            XAU.Services.WamAuthService.SetExternalToken(sel.Xbl, sel.Xuid, sel.Uhs);
+            XAUTH = sel.Xbl;
+            XUIDOnly = sel.Xuid;
+            _selectedGdkXuid = sel.Xuid;
+            AchievementsViewModel.EventsToken = eventsToken;
+            EventsLog($"GDK login: {sel.Gamertag} ({sel.Xuid}) | events={eventsSource}");
+            _xboxRestAPI = new Lazy<XboxRestAPI>(() => new XboxRestAPI(XAUTH));
+            InitComplete = true;
+            IsLoggedIn = true;
+            LoginText = "Logged In";
+        }
+
+        // Acha a conta Windows (WAM) cujo login silencioso resolve nesse xuid e retorna o
+        // events token device-bound dela, setando _currentWamAccount no match. Só silencioso,
+        // nunca abre diálogo. Null quando nenhuma conta Windows bate com o xuid escolhido.
+        private async Task<string?> TryGetWamEventsTokenAsync(string xuid)
+        {
+            _currentWamAccount = null;
+            foreach (var acct in _wamAccounts)
+            {
+                try
+                {
+                    if (!await XAU.Services.WamAuthService.LoginAsync(acct)) continue;
+                    if (XAU.Services.WamAuthService.Xuid == xuid)
+                    {
+                        _currentWamAccount = acct;
+                        return XAU.Services.WamAuthService.GetEventsToken();
+                    }
+                }
+                catch (Exception ex) { EventsLog($"wam events probe failed: {ex.Message}"); }
+            }
+            return null;
+        }
+
+        // Diálogo de seleção de conta. Retorna o índice escolhido, ou -1 se cancelado.
+        private async Task<int> ShowAccountPickerAsync(string title, List<string> labels)
+        {
+            var itemContainerStyle = new Style(typeof(System.Windows.Controls.ListBoxItem));
+            itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.PaddingProperty, new Thickness(8, 6, 8, 6)));
+            itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.MarginProperty, new Thickness(0, 2, 0, 2)));
+            itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BorderThicknessProperty, new Thickness(1)));
+            itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BorderBrushProperty, System.Windows.Media.Brushes.Transparent));
+            itemContainerStyle.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.CursorProperty, System.Windows.Input.Cursors.Hand));
+            var hoverTrigger = new Trigger { Property = System.Windows.Controls.ListBoxItem.IsMouseOverProperty, Value = true };
+            hoverTrigger.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BackgroundProperty,
+                new SolidColorBrush(System.Windows.Media.Color.FromArgb(0x20, 0x60, 0xCD, 0xFF))));
+            hoverTrigger.Setters.Add(new Setter(System.Windows.Controls.ListBoxItem.BorderBrushProperty,
+                new SolidColorBrush(System.Windows.Media.Color.FromArgb(0x40, 0x60, 0xCD, 0xFF))));
+            itemContainerStyle.Triggers.Add(hoverTrigger);
+
+            var listBox = new ListBox
+            {
+                ItemsSource = labels,
+                ItemContainerStyle = itemContainerStyle,
+                BorderThickness = new Thickness(0),
+                Background = System.Windows.Media.Brushes.Transparent
+            };
+
+            var result = await _contentDialogService.ShowSimpleDialogAsync(
+                new SimpleContentDialogCreateOptions()
+                {
+                    Title = title,
+                    Content = new System.Windows.Controls.ScrollViewer { MaxHeight = 300, Content = listBox },
+                    PrimaryButtonText = "Select",
+                    CloseButtonText = "Cancel"
+                });
+            if (result != ContentDialogResult.Primary || listBox.SelectedIndex < 0)
+                return -1;
+            return listBox.SelectedIndex;
         }
 
         #endregion
@@ -492,7 +592,6 @@ namespace XAU.ViewModels.Pages
                 var person = profileResponse.People.FirstOrDefault();
                 if (Settings.PrivacyMode)
                 {
-                    // Display hidden profile details for privacy mode
                     GamerTag = "Gamertag: Hidden";
                     Xuid = "XUID: Hidden";
                     GamerPic = "pack://application:,,,/Assets/cirno.png";
@@ -511,7 +610,6 @@ namespace XAU.ViewModels.Pages
                 }
                 else
                 {
-                    // Populate user profile details
                     GamerTag = $"Gamertag: {person?.Gamertag ?? "Unknown"}";
                     Xuid = $"XUID: {person?.Xuid ?? "Unknown"}";
                     GamerPic = (person?.DisplayPicRaw?.Replace("&mode=Padding", "")) ?? "pack://application:,,,/Assets/default.png";
@@ -519,7 +617,6 @@ namespace XAU.ViewModels.Pages
                     ProfileRep = $"Reputation: {person?.XboxOneRep ?? "Unknown"}";
                     AccountTier = $"Tier: {person?.Detail?.AccountTier ?? "Unknown"}";
 
-                    // Currently playing information
                     var presence = person?.PresenceDetails?.FirstOrDefault();
                     if (presence?.TitleId == null)
                     {
@@ -531,7 +628,6 @@ namespace XAU.ViewModels.Pages
                         CurrentlyPlaying = gameTitle?.Titles?.FirstOrDefault()?.Name ?? $"Currently Playing: Unknown ({presence.TitleId})";
                     }
 
-                    // Retrieve Gamepass Membership Information
                     try
                     {
                         var gpuResponse = await _xboxRestAPI.Value.GetGamepassMembershipAsync(XUIDOnly);
@@ -542,10 +638,8 @@ namespace XAU.ViewModels.Pages
                         Gamepass = "Gamepass: Unknown";
                     }
 
-                    // Active Device Information
                     ActiveDevice = $"Active Device: {presence?.Device ?? "Unknown"}";
 
-                    // Detailed profile information
                     if (person?.Detail != null)
                     {
                         IsVerified = $"Verified: {person.Detail.IsVerified}";
@@ -555,10 +649,8 @@ namespace XAU.ViewModels.Pages
                         Followers = $"Followers: {person.Detail.FollowerCount}";
                         Bio = $"Bio: {person.Detail.Bio ?? "No Bio"}";
 
-                        // Handle Watermarks
                         Watermarks.Clear();
 
-                        // Parse Tenure Badge
                         if (int.TryParse(person.Detail.Tenure, out int tenureInt))
                         {
                             string tenureBadge = tenureInt.ToString("D2");
@@ -569,7 +661,6 @@ namespace XAU.ViewModels.Pages
                             Console.WriteLine("The tenure string is not a valid integer.");
                         }
 
-                        // Add Launch Watermarks
                         if (person.Detail.Watermarks != null)
                         {
                             foreach (var watermark in person.Detail.Watermarks)
@@ -613,6 +704,21 @@ namespace XAU.ViewModels.Pages
 
         private async Task RefreshTokens()
         {
+            // Caminho GDK: relê o xauth enrolled do disco + remint do events token.
+            // O Gaming Services mantém o token em disco rotacionado, então pega o mais novo.
+            if (_selectedGdkXuid != null)
+            {
+                var sel = XAU.Services.GdkTokenService.GetXboxLiveTokens().FirstOrDefault(t => t.Xuid == _selectedGdkXuid);
+                if (sel == null)
+                {
+                    EventsLog("refresh: no enrolled token on disk (open the Microsoft Store / Xbox app to refresh it)");
+                    return;
+                }
+                await ApplyGdkLoginAsync(sel);
+                EventsLog("GDK tokens refreshed");
+                return;
+            }
+
             if (_currentWamAccount == null) return;
 
             var success = await XAU.Services.WamAuthService.LoginAsync(_currentWamAccount);

--- a/XAU/ViewModels/Pages/QueueViewModel.cs
+++ b/XAU/ViewModels/Pages/QueueViewModel.cs
@@ -1,0 +1,568 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading;
+using Microsoft.Data.Sqlite;
+using Newtonsoft.Json;
+using Wpf.Ui.Common;
+using Wpf.Ui.Contracts;
+using Wpf.Ui.Controls;
+using XAU.Services.AutoUnlock;
+
+namespace XAU.ViewModels.Pages
+{
+    // Resultado de rodar um título da fila.
+    public enum QueueRunResult { Completed, AlreadyComplete, Failed, Invalid }
+
+    // Um jogo já confirmado na fila.
+    public partial class QueuedGame : ObservableObject
+    {
+        public string TitleId { get; set; } = "";
+        public string GameName { get; set; } = "";
+        public string Gamertag { get; set; } = "";
+        public int AchievementCount { get; set; }
+        public long EstimateSeconds { get; set; }
+        public string EstimateText { get; set; } = "";
+        [ObservableProperty] private string _status = "Queued";
+        [ObservableProperty] private string _statusColor = "#9AA0A6";
+    }
+
+    // Linha da pré-visualização da ordem (antes de confirmar).
+    public partial class OrderPreviewItem : ObservableObject
+    {
+        public int Position { get; set; }
+        public string Name { get; set; } = "";
+        public string DelayText { get; set; } = "";
+        public bool Skipped { get; set; }
+        public double NameOpacity => Skipped ? 0.4 : 1.0;
+        public string PositionText => Skipped ? "—" : Position.ToString();
+    }
+
+    public partial class QueueViewModel : ObservableObject, INavigationAware
+    {
+        private readonly ISnackbarService _snackbar;
+        private readonly AchievementsViewModel _achievements;
+        private readonly INavigationService _navigation;
+        private readonly Lazy<XboxRestAPI> _api = new(() => new XboxRestAPI(HomeViewModel.XAUTH));
+        private readonly TimeSpan _snackDur = TimeSpan.FromSeconds(2);
+        private CancellationTokenSource? _runCts;
+
+        [ObservableProperty] private ObservableCollection<QueuedGame> _games = new();
+
+        // --- Busca ---
+        [ObservableProperty] private string _searchText = "";
+        [ObservableProperty] private ObservableCollection<GameItem> _searchResults = new();
+        [ObservableProperty] private GameItem? _selectedResult;
+
+        // --- Rascunho (jogo escolhido, ainda não adicionado) ---
+        [ObservableProperty][NotifyPropertyChangedFor(nameof(HasSelection))] private string _draftTitleId = "";
+        [ObservableProperty] private string _draftName = "";
+        [ObservableProperty] private string _draftGamertag = "";
+        [ObservableProperty][NotifyPropertyChangedFor(nameof(HasOrder))] private bool _orderBuilt;
+        [ObservableProperty] private string _draftSummary = "";
+        [ObservableProperty] private ObservableCollection<OrderPreviewItem> _preview = new();
+
+        [ObservableProperty][NotifyPropertyChangedFor(nameof(CanEdit))] private bool _isBusy;
+        [ObservableProperty] private string _cooldownMinutes = "10";
+
+        // --- Execução ---
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IsIdle))]
+        [NotifyPropertyChangedFor(nameof(CanEdit))]
+        private bool _isRunning;
+        [ObservableProperty] private string _runStatus = "";
+        [ObservableProperty] private string _cooldownText = "";
+        [ObservableProperty] private string _queueEtaText = "";
+
+        private string _lastGamertag = "";
+
+        partial void OnCooldownMinutesChanged(string value) => RecomputeEta();
+
+        public bool IsIdle => !IsRunning;
+        public bool CanEdit => !IsRunning && !IsBusy;
+        public bool HasSelection => !string.IsNullOrEmpty(DraftTitleId);
+        public bool HasOrder => OrderBuilt;
+
+        public QueueViewModel(ISnackbarService snackbar, AchievementsViewModel achievements, INavigationService navigation)
+        {
+            _snackbar = snackbar;
+            _achievements = achievements;
+            _navigation = navigation;
+            Games.CollectionChanged += (_, _) => RecomputeEta();
+        }
+
+        // Adiciona direto na fila (usado pelo botão "Add to Queue" da tela de Achievements,
+        // onde a ordem já foi gerada). Sem gamertag: roda pela ordem já salva no disco.
+        public void AddGameDirect(string titleId, string gameName)
+        {
+            if (string.IsNullOrWhiteSpace(titleId)) return;
+            if (Games.Any(x => x.TitleId == titleId))
+            {
+                _snackbar.Show("Queue", "That game is already in the queue.", ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+
+            var order = OrderRepository.Load(titleId);
+            var skip = OrderRepository.LoadSkip(titleId);
+            int count = order?.Items.Count(i => !skip.Contains(i.Id)) ?? 0;
+            long secs = order?.Items.Where(i => !skip.Contains(i.Id)).Sum(i => i.DelaySeconds) ?? 0;
+
+            Games.Add(new QueuedGame
+            {
+                TitleId = titleId,
+                GameName = string.IsNullOrWhiteSpace(gameName) ? titleId : gameName,
+                Gamertag = "",
+                AchievementCount = count,
+                EstimateSeconds = secs,
+                EstimateText = $"{count} achievements • ~{FormatSpan(secs)}"
+            });
+            SaveToDisk();
+            _snackbar.Show("Added to queue", $"{gameName} is now in the queue.", ControlAppearance.Success,
+                new SymbolIcon(SymbolRegular.Checkmark24), _snackDur);
+        }
+
+        // ETA da fila inteira: soma os jogos ainda pendentes + os cooldowns entre eles.
+        private void RecomputeEta()
+        {
+            var pending = Games.Where(g => !IsFinished(g.Status)).ToList();
+            if (pending.Count == 0) { QueueEtaText = ""; return; }
+            int cooldown = int.TryParse(CooldownMinutes, out var m) ? Math.Max(0, m) : 10;
+            long total = pending.Sum(g => g.EstimateSeconds) + (long)Math.Max(0, pending.Count - 1) * cooldown * 60;
+            QueueEtaText = $"Whole queue ~{FormatSpan(total)} ({pending.Count} game{(pending.Count == 1 ? "" : "s")}, incl. cooldowns)";
+        }
+
+        public void OnNavigatedTo()
+        {
+            if (Games.Count == 0)
+                LoadFromDisk();
+            _lastGamertag = LoadLastGamertag();
+            RecomputeEta();
+        }
+
+        public void OnNavigatedFrom() { }
+
+        #region Busca de jogos
+
+        [RelayCommand]
+        private async Task SearchGames()
+        {
+            var q = SearchText.Trim();
+            if (string.IsNullOrWhiteSpace(q))
+            {
+                SearchResults = new ObservableCollection<GameItem>();
+                return;
+            }
+
+            var db = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                "XAU", "TitleSearch", "xbox_games.db");
+            if (!File.Exists(db))
+            {
+                _snackbar.Show("Queue", "Game database isn't ready yet — give it a moment to download.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+
+            IsBusy = true;
+            try
+            {
+                var list = await Task.Run(() => QueryGames(db, q));
+                SearchResults = new ObservableCollection<GameItem>(list);
+                if (list.Count == 0)
+                    _snackbar.Show("Queue", $"No games matched \"{q}\".", ControlAppearance.Caution,
+                        new SymbolIcon(SymbolRegular.Search24), _snackDur);
+            }
+            catch (Exception ex)
+            {
+                _snackbar.Show("Search failed", ex.Message, ControlAppearance.Danger,
+                    new SymbolIcon(SymbolRegular.ErrorCircle24), _snackDur);
+            }
+            finally { IsBusy = false; }
+        }
+
+        private static List<GameItem> QueryGames(string dbPath, string query)
+        {
+            var results = new List<GameItem>();
+            using var conn = new SqliteConnection($"Data Source={dbPath}");
+            conn.Open();
+            using var cmd = new SqliteCommand(
+                "SELECT title, titleId, isTitleBased FROM games WHERE title LIKE @q ORDER BY title COLLATE NOCASE LIMIT 50", conn);
+            cmd.Parameters.AddWithValue("@q", $"%{query}%");
+            using var reader = cmd.ExecuteReader();
+            int iTitle = reader.GetOrdinal("title");
+            int iId = reader.GetOrdinal("titleId");
+            int iTb = reader.GetOrdinal("isTitleBased");
+            while (reader.Read())
+                results.Add(new GameItem
+                {
+                    Title = reader.GetString(iTitle),
+                    TitleId = reader.GetString(iId),
+                    IsTitleBased = reader.GetInt32(iTb) == 1
+                });
+            return results;
+        }
+
+        // Escolher um resultado vira o rascunho atual.
+        partial void OnSelectedResultChanged(GameItem? value)
+        {
+            if (value == null) return;
+            DraftTitleId = value.TitleId;
+            DraftName = value.Title;
+            OrderBuilt = false;
+            Preview = new ObservableCollection<OrderPreviewItem>();
+            DraftSummary = "";
+            // Pré-preenche com o último gamertag usado (a galera costuma espelhar o mesmo).
+            if (string.IsNullOrWhiteSpace(DraftGamertag) && !string.IsNullOrWhiteSpace(_lastGamertag))
+                DraftGamertag = _lastGamertag;
+        }
+
+        #endregion
+
+        #region Rascunho da ordem
+
+        [RelayCommand]
+        private async Task BuildOrder()
+        {
+            if (!HasSelection)
+            {
+                _snackbar.Show("Queue", "Pick a game from the search results first.", ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+            var gt = DraftGamertag.Trim();
+            if (string.IsNullOrWhiteSpace(gt))
+            {
+                _snackbar.Show("Queue", "Enter a reference gamertag to mirror.", ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+            if (!HomeViewModel.InitComplete)
+            {
+                _snackbar.Show("Queue", "Sign in before building an order.", ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+
+            IsBusy = true;
+            try
+            {
+                var order = await OrderRepository.GenerateFromReferenceAsync(
+                    _api.Value, DraftTitleId, DraftName, gt, new HashSet<string>());
+                OrderRepository.Save(order);
+                _lastGamertag = gt;
+                SaveLastGamertag(gt);
+                OrderBuilt = true;
+                RefreshPreview();
+                _snackbar.Show("Order ready", $"{order.Items.Count} achievements mirrored from {gt}. Tweak or add it.",
+                    ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackDur);
+            }
+            catch (Exception ex)
+            {
+                OrderBuilt = false;
+                _snackbar.Show("Couldn't build order", ex.Message, ControlAppearance.Danger,
+                    new SymbolIcon(SymbolRegular.ErrorCircle24), _snackDur);
+            }
+            finally { IsBusy = false; }
+        }
+
+        [RelayCommand]
+        private async Task EditDraftDelays()
+        {
+            if (!HasOrder) return;
+            await _achievements.EditDelaysForTitleAsync(DraftTitleId);
+            RefreshPreview();
+        }
+
+        [RelayCommand]
+        private async Task EditDraftSkip()
+        {
+            if (!HasOrder) return;
+            await _achievements.EditSkipListForTitleAsync(DraftTitleId);
+            RefreshPreview();
+        }
+
+        [RelayCommand]
+        private void ConfirmAdd()
+        {
+            if (!HasOrder || !HasSelection) return;
+            if (Games.Any(x => x.TitleId == DraftTitleId))
+            {
+                _snackbar.Show("Queue", "That game is already in the queue.", ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+
+            var order = OrderRepository.Load(DraftTitleId);
+            var skip = OrderRepository.LoadSkip(DraftTitleId);
+            int count = order?.Items.Count(i => !skip.Contains(i.Id)) ?? 0;
+            long secs = order?.Items.Where(i => !skip.Contains(i.Id)).Sum(i => i.DelaySeconds) ?? 0;
+
+            Games.Add(new QueuedGame
+            {
+                TitleId = DraftTitleId,
+                GameName = DraftName,
+                Gamertag = DraftGamertag.Trim(),
+                AchievementCount = count,
+                EstimateSeconds = secs,
+                EstimateText = $"{count} achievements • ~{FormatSpan(secs)}"
+            });
+            SaveToDisk();
+            RecomputeEta();
+            ResetDraft();
+            _snackbar.Show("Added to queue", "Line up another or press Start.", ControlAppearance.Success,
+                new SymbolIcon(SymbolRegular.Checkmark24), _snackDur);
+        }
+
+        [RelayCommand]
+        private void DiscardDraft() => ResetDraft();
+
+        private void ResetDraft()
+        {
+            SelectedResult = null;
+            DraftTitleId = "";
+            DraftName = "";
+            DraftGamertag = "";
+            OrderBuilt = false;
+            Preview = new ObservableCollection<OrderPreviewItem>();
+            DraftSummary = "";
+        }
+
+        // Recarrega ordem + skip do disco e remonta a pré-visualização.
+        private void RefreshPreview()
+        {
+            var items = new ObservableCollection<OrderPreviewItem>();
+            var order = OrderRepository.Load(DraftTitleId);
+            if (order == null)
+            {
+                Preview = items;
+                DraftSummary = "";
+                return;
+            }
+
+            var skip = OrderRepository.LoadSkip(DraftTitleId);
+            long secs = 0;
+            int pos = 1, included = 0;
+            foreach (var it in order.Items)
+            {
+                bool sk = skip.Contains(it.Id);
+                if (!sk) { secs += it.DelaySeconds; included++; }
+                items.Add(new OrderPreviewItem
+                {
+                    Position = pos++,
+                    Name = it.Name,
+                    DelayText = it.DelaySeconds <= 0 ? "start" : FormatSpan(it.DelaySeconds),
+                    Skipped = sk
+                });
+            }
+
+            Preview = items;
+            DraftSummary = $"{included} of {order.Items.Count} achievements • ~{FormatSpan(secs)}";
+        }
+
+        #endregion
+
+        #region Fila (reordenar / remover / rodar)
+
+        [RelayCommand]
+        private void Remove(QueuedGame? game)
+        {
+            if (game == null || IsRunning) return;
+            Games.Remove(game);
+            SaveToDisk();
+        }
+
+        [RelayCommand]
+        private void MoveUp(QueuedGame? game)
+        {
+            if (game == null || IsRunning) return;
+            int i = Games.IndexOf(game);
+            if (i > 0) { Games.Move(i, i - 1); SaveToDisk(); }
+        }
+
+        [RelayCommand]
+        private void MoveDown(QueuedGame? game)
+        {
+            if (game == null || IsRunning) return;
+            int i = Games.IndexOf(game);
+            if (i >= 0 && i < Games.Count - 1) { Games.Move(i, i + 1); SaveToDisk(); }
+        }
+
+        [RelayCommand]
+        private void ClearQueue()
+        {
+            if (IsRunning) return;
+            Games.Clear();
+            SaveToDisk();
+        }
+
+        [RelayCommand]
+        private async Task StartQueue()
+        {
+            if (IsRunning) return;
+            if (Games.Count == 0)
+            {
+                _snackbar.Show("Queue", "Add a game first.", ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+            if (!HomeViewModel.InitComplete)
+            {
+                _snackbar.Show("Queue", "Sign in before starting.", ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+
+            int cooldown = int.TryParse(CooldownMinutes, out var m) ? Math.Max(0, m) : 10;
+            _runCts = new CancellationTokenSource();
+            IsRunning = true;
+
+            // Leva pra tela de Achievements pra acompanhar o painel do auto unlocker ao vivo.
+            try { _navigation.Navigate(typeof(XAU.Views.Pages.AchievementsPage)); } catch { }
+
+            try
+            {
+                var pending = Games.ToList();
+                for (int i = 0; i < pending.Count; i++)
+                {
+                    if (_runCts.IsCancellationRequested) break;
+                    var g = pending[i];
+                    if (IsFinished(g.Status)) continue;
+
+                    SetStatus(g, "Unlocking", "#60CDFF");
+                    RunStatus = $"Game {i + 1} of {pending.Count} — {g.GameName}";
+
+                    QueueRunResult result;
+                    try { result = await _achievements.RunQueuedTitleAsync(g.TitleId, g.Gamertag, _runCts.Token); }
+                    catch { result = QueueRunResult.Failed; }
+
+                    if (_runCts.IsCancellationRequested) { SetStatus(g, "Stopped", "#9AA0A6"); break; }
+
+                    bool skipped = result == QueueRunResult.AlreadyComplete;
+                    if (result == QueueRunResult.Completed || result == QueueRunResult.AlreadyComplete)
+                        SetStatus(g, skipped ? "Already 100%" : "Done", "#6BD968");
+                    else
+                        SetStatus(g, "Failed", "#FF6B6B");
+                    SaveToDisk();
+
+                    // Jogo já 100% não roda nada -> não precisa esperar o cooldown.
+                    bool hasNext = pending.Skip(i + 1).Any(x => !IsFinished(x.Status));
+                    if (hasNext && cooldown > 0 && !skipped && !_runCts.IsCancellationRequested)
+                        await CooldownAsync(cooldown, _runCts.Token);
+                }
+
+                RunStatus = _runCts.IsCancellationRequested ? "Queue stopped." : "Queue finished.";
+            }
+            finally
+            {
+                IsRunning = false;
+                CooldownText = "";
+                _runCts?.Dispose();
+                _runCts = null;
+            }
+        }
+
+        [RelayCommand]
+        private void StopQueue() => _runCts?.Cancel();
+
+        private async Task CooldownAsync(int minutes, CancellationToken ct)
+        {
+            var until = DateTime.Now.AddMinutes(minutes);
+            while (!ct.IsCancellationRequested)
+            {
+                var left = until - DateTime.Now;
+                if (left <= TimeSpan.Zero) break;
+                CooldownText = $"Cooldown — next game in {left:mm\\:ss}";
+                try { await Task.Delay(1000, ct); }
+                catch { break; }
+            }
+            CooldownText = "";
+        }
+
+        private void SetStatus(QueuedGame g, string status, string color)
+        {
+            g.Status = status;
+            g.StatusColor = color;
+            RecomputeEta();
+        }
+
+        // Jogos concluídos (ou já 100%) saem da conta e são pulados na próxima execução.
+        private static bool IsFinished(string status) => status == "Done" || status == "Already 100%";
+
+        #endregion
+
+        private static string FormatSpan(long seconds)
+        {
+            var t = TimeSpan.FromSeconds(seconds);
+            if (t.TotalHours >= 1) return $"{(int)t.TotalHours}h {t.Minutes}m";
+            if (t.TotalMinutes >= 1) return $"{t.Minutes}m {t.Seconds}s";
+            return $"{t.Seconds}s";
+        }
+
+        #region Persistência
+
+        private static string QueueDir => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU", "Queue");
+        private static string QueueFile => Path.Combine(QueueDir, "queue.json");
+        private static string LastGamertagFile => Path.Combine(QueueDir, "last_gamertag.txt");
+
+        private record QueueDto(string TitleId, string GameName, string Gamertag, int AchievementCount,
+            long EstimateSeconds, string EstimateText, string? Status, string? StatusColor);
+
+        private void SaveToDisk()
+        {
+            try
+            {
+                Directory.CreateDirectory(QueueDir);
+                var dto = Games.Select(g => new QueueDto(g.TitleId, g.GameName, g.Gamertag, g.AchievementCount,
+                    g.EstimateSeconds, g.EstimateText, g.Status, g.StatusColor)).ToList();
+                File.WriteAllText(QueueFile, JsonConvert.SerializeObject(dto, Formatting.Indented));
+            }
+            catch { }
+        }
+
+        private void LoadFromDisk()
+        {
+            try
+            {
+                if (!File.Exists(QueueFile)) return;
+                var dto = JsonConvert.DeserializeObject<List<QueueDto>>(File.ReadAllText(QueueFile));
+                if (dto == null) return;
+                Games.Clear();
+                foreach (var d in dto)
+                {
+                    // Só status terminais sobrevivem ao restart; o resto volta pra "Queued".
+                    bool finished = IsFinished(d.Status ?? "") || d.Status == "Failed";
+                    Games.Add(new QueuedGame
+                    {
+                        TitleId = d.TitleId,
+                        GameName = d.GameName,
+                        Gamertag = d.Gamertag,
+                        AchievementCount = d.AchievementCount,
+                        EstimateSeconds = d.EstimateSeconds,
+                        EstimateText = d.EstimateText,
+                        Status = finished ? d.Status! : "Queued",
+                        StatusColor = finished ? (d.StatusColor ?? "#6BD968") : "#9AA0A6"
+                    });
+                }
+            }
+            catch { }
+        }
+
+        private static string LoadLastGamertag()
+        {
+            try { return File.Exists(LastGamertagFile) ? File.ReadAllText(LastGamertagFile).Trim() : ""; }
+            catch { return ""; }
+        }
+
+        private static void SaveLastGamertag(string gamertag)
+        {
+            try
+            {
+                Directory.CreateDirectory(QueueDir);
+                File.WriteAllText(LastGamertagFile, gamertag.Trim());
+            }
+            catch { }
+        }
+
+        #endregion
+    }
+}

--- a/XAU/ViewModels/Pages/SettingsViewModel.cs
+++ b/XAU/ViewModels/Pages/SettingsViewModel.cs
@@ -1,6 +1,8 @@
 using Newtonsoft.Json;
 using System.Diagnostics;
 using System.IO;
+using Wpf.Ui.Common;
+using Wpf.Ui.Contracts;
 using Wpf.Ui.Controls;
 using XAU.Services.HttpServer;
 
@@ -8,6 +10,16 @@ namespace XAU.ViewModels.Pages
 {
     public partial class SettingsViewModel : ObservableObject, INavigationAware, IDisposable
     {
+        private readonly ISnackbarService _snackbar;
+        private readonly IContentDialogService _dialogs;
+        private readonly TimeSpan _snackDur = TimeSpan.FromSeconds(2);
+
+        public SettingsViewModel(ISnackbarService snackbar, IContentDialogService dialogs)
+        {
+            _snackbar = snackbar;
+            _dialogs = dialogs;
+        }
+
         private bool _isInitialized = false;
 
         [ObservableProperty]
@@ -15,7 +27,6 @@ namespace XAU.ViewModels.Pages
 
         static string ProgramFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU");
         string SettingsFilePath = Path.Combine(ProgramFolderPath, "settings.json");
-        //settings
         [ObservableProperty] private string _settingsVersion;
         [ObservableProperty] private string _toolVersion;
         [ObservableProperty] private bool _unlockAllEnabled;
@@ -50,7 +61,7 @@ namespace XAU.ViewModels.Pages
             };
             string settingsJson = JsonConvert.SerializeObject(settings);
             File.WriteAllText(SettingsFilePath, settingsJson);
-            HomeViewModel.Settings = settings; // update ref
+            HomeViewModel.Settings = settings; // atualiza a referência
         }
 
         [RelayCommand]
@@ -75,7 +86,7 @@ namespace XAU.ViewModels.Pages
                 _httpServer.Stop();
                 ListeningAddress = $"http://localhost:{ServerPort}";
             }
-            // TO DO: SAVE SERVER ENABLED/DISABLED STATUS & PORT NUMBER
+            // TODO: salvar status (ligado/desligado) do servidor e número da porta
             //SaveSettings();
         }
 
@@ -88,7 +99,7 @@ namespace XAU.ViewModels.Pages
                 UpdateListeningAddress();
             }
 
-            // TO DO: SAVE SERVER ENABLED/DISABLED STATUS & PORT NUMBER
+            // TODO: salvar status (ligado/desligado) do servidor e número da porta
             //SaveSettings();
         }
 
@@ -119,6 +130,71 @@ namespace XAU.ViewModels.Pages
             {
                 Debug.WriteLine($"Failed to open address: {ex.Message}");
             }
+        }
+
+        [RelayCommand]
+        private void CopyXauth() => CopyToClipboard(HomeViewModel.XAUTH, "xauth token");
+
+        [RelayCommand]
+        private void CopyEventToken() => CopyToClipboard(AchievementsViewModel.EventsToken, "event token");
+
+        // Copia o token pro clipboard com feedback (ou avisa que não tem token ainda).
+        private void CopyToClipboard(string? value, string label)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                _snackbar.Show("Nothing to copy", $"No {label} yet — sign in first.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackDur);
+                return;
+            }
+
+            // O clipboard pode estar travado por outro processo (comum em VM/clipboard
+            // managers). Usa o retry embutido do WPF; se mesmo assim não entrar, mostra o
+            // token num diálogo pra copiar na mão (Ctrl+C).
+            try
+            {
+                // WinForms tem o overload com retry embutido (15x a cada 120ms).
+                System.Windows.Forms.Clipboard.SetDataObject(value, true, 15, 120);
+                _snackbar.Show("Copied", $"The {label} is on your clipboard.",
+                    ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackDur);
+            }
+            catch
+            {
+                ShowTokenManually(value, label);
+            }
+        }
+
+        // Fallback: clipboard inacessível -> exibe o token selecionável pra copiar na mão.
+        private async void ShowTokenManually(string value, string label)
+        {
+            var hint = new System.Windows.Controls.TextBlock
+            {
+                Text = "Couldn't reach the clipboard (it may be locked by a VM clipboard sync or a clipboard manager). Select the text below and press Ctrl+C.",
+                TextWrapping = System.Windows.TextWrapping.Wrap,
+                Opacity = 0.85,
+                Margin = new System.Windows.Thickness(0, 0, 0, 10)
+            };
+            var box = new System.Windows.Controls.TextBox
+            {
+                Text = value,
+                IsReadOnly = true,
+                TextWrapping = System.Windows.TextWrapping.Wrap,
+                MinWidth = 440,
+                MaxHeight = 180,
+                VerticalScrollBarVisibility = System.Windows.Controls.ScrollBarVisibility.Auto
+            };
+            box.Loaded += (_, _) => { box.Focus(); box.SelectAll(); };
+
+            var panel = new System.Windows.Controls.StackPanel();
+            panel.Children.Add(hint);
+            panel.Children.Add(box);
+
+            await _dialogs.ShowSimpleDialogAsync(new SimpleContentDialogCreateOptions()
+            {
+                Title = $"Copy the {label}",
+                Content = panel,
+                CloseButtonText = "Close"
+            });
         }
 
         public void OnNavigatedTo()
@@ -184,7 +260,7 @@ namespace XAU.ViewModels.Pages
                 _httpServer.UpdatePort(value);
                 UpdateListeningAddress();
             }
-            // TO DO: SAVE SERVER ENABLED/DISABLED STATUS & PORT NUMBER
+            // TODO: salvar status (ligado/desligado) do servidor e número da porta
             //SaveSettings();
         }
         public void Dispose()

--- a/XAU/ViewModels/Pages/StatsViewModel.cs
+++ b/XAU/ViewModels/Pages/StatsViewModel.cs
@@ -1,20 +1,171 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using Wpf.Ui.Common;
+using Wpf.Ui.Contracts;
 using Wpf.Ui.Controls;
+using XAU.Services.StatEditor;
 
 namespace XAU.ViewModels.Pages
 {
     public partial class StatsViewModel : ObservableObject, INavigationAware
     {
+        private readonly ISnackbarService _snackbarService;
+        private readonly TimeSpan _snackbarDuration = TimeSpan.FromSeconds(2);
         private bool _isInitialized = false;
+
+        public StatsViewModel(ISnackbarService snackbarService)
+        {
+            _snackbarService = snackbarService;
+        }
+
+        // Uma linha editável de stat no grid. ObservableObject pra que edição e leitura
+        // de volta cheguem na UI.
+        public partial class StatRow : ObservableObject
+        {
+            public string Name { get; set; } = "";
+            public string DisplayName { get; set; } = "";
+            public string StatType { get; set; } = "";
+            public string Scid { get; set; } = "";
+            [ObservableProperty] private string _value = "0";
+            // Feedback de salvamento por linha ("", "Saving...", "✓", "✗").
+            [ObservableProperty] private string _status = "";
+        }
+
+        [ObservableProperty] private string _titleId = "";
+        [ObservableProperty] private bool _isBusy = false;
+        // Inverso de IsBusy, pra desabilitar o botão Load enquanto um load roda.
+        [ObservableProperty] private bool _notBusy = true;
+        [ObservableProperty] private string _statusText = "Enter a Title ID and press Load.";
+        [ObservableProperty] private string _filterText = "";
+        [ObservableProperty] private ObservableCollection<StatRow> _stats = new ObservableCollection<StatRow>();
+
+        // Conjunto completo sem filtro; Stats é a view filtrada disto.
+        private readonly List<StatRow> _allStats = new List<StatRow>();
+
+        partial void OnIsBusyChanged(bool value) => NotBusy = !value;
+        partial void OnFilterTextChanged(string value) => ApplyFilter();
+
+        // Reconstrói Stats a partir de _allStats aplicando o filtro atual.
+        private void ApplyFilter()
+        {
+            var f = FilterText?.Trim() ?? "";
+            Stats.Clear();
+            foreach (var r in _allStats)
+            {
+                if (f.Length == 0
+                    || (r.DisplayName?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || (r.Name?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false))
+                {
+                    Stats.Add(r);
+                }
+            }
+        }
+
         public void OnNavigatedTo()
         {
             if (!_isInitialized)
                 InitializeViewModel();
+            // Conveniência: pré-preenche com o título aberto na tela de Achievements.
+            if (string.IsNullOrWhiteSpace(TitleId) && AchievementsViewModel.TitleID != "0")
+                TitleId = AchievementsViewModel.TitleID;
         }
+
         public void OnNavigatedFrom() { }
 
         private void InitializeViewModel()
         {
             _isInitialized = true;
+        }
+
+        [RelayCommand]
+        public async Task LoadStats()
+        {
+            if (!HomeViewModel.InitComplete)
+            {
+                _snackbarService.Show("Stat Editor", "Sign in before using this.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(TitleId))
+            {
+                _snackbarService.Show("Stat Editor", "Enter a Title ID first.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+
+            IsBusy = true;
+            StatusText = "Loading stats...";
+            _allStats.Clear();
+            Stats.Clear();
+            try
+            {
+                var service = new StatEditorService(HomeViewModel.XAUTH, HomeViewModel.XUIDOnly);
+                var stats = await service.ReadStatsAsync(TitleId.Trim(), CancellationToken.None);
+                foreach (var s in stats)
+                {
+                    _allStats.Add(new StatRow
+                    {
+                        Name = s.Name,
+                        DisplayName = s.DisplayName,
+                        Value = s.Value,
+                        StatType = s.StatType,
+                        Scid = s.Scid
+                    });
+                }
+                ApplyFilter();
+                StatusText = _allStats.Count > 0
+                    ? $"Loaded {_allStats.Count} stat(s). Edit a value and press Save."
+                    : "No editable stats found for this title.";
+            }
+            catch (Exception ex)
+            {
+                StatusText = "Failed to load stats.";
+                _snackbarService.Show("Stat Editor", ex.Message,
+                    ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        [RelayCommand]
+        public async Task SaveStat(StatRow? row)
+        {
+            if (row == null)
+                return;
+            if (!HomeViewModel.InitComplete)
+            {
+                _snackbarService.Show("Stat Editor", "Sign in before using this.",
+                    ControlAppearance.Caution, new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(row.Scid))
+            {
+                row.Status = "✗";
+                _snackbarService.Show("Stat Editor", "This stat has no SCID and cannot be written.",
+                    ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+                return;
+            }
+
+            row.Status = "Saving...";
+            try
+            {
+                var service = new StatEditorService(HomeViewModel.XAUTH, HomeViewModel.XUIDOnly);
+                var (ok, message) = await service.WriteStatAsync(
+                    TitleId.Trim(), row.Scid, row.Name, row.Value.Trim(), CancellationToken.None);
+                row.Status = ok ? "✓" : "⏳";
+                _snackbarService.Show("Stat Editor", message,
+                    ok ? ControlAppearance.Success : ControlAppearance.Caution,
+                    new SymbolIcon(ok ? SymbolRegular.Checkmark24 : SymbolRegular.Warning24), _snackbarDuration);
+            }
+            catch (Exception ex)
+            {
+                row.Status = "✗";
+                _snackbarService.Show("Stat Editor", ex.Message,
+                    ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+            }
         }
     }
 }

--- a/XAU/ViewModels/Windows/MainWindowViewModel.cs
+++ b/XAU/ViewModels/Windows/MainWindowViewModel.cs
@@ -67,12 +67,18 @@ namespace XAU.ViewModels.Windows
                 Icon = new SymbolIcon { Symbol = SymbolRegular.Trophy24 },
                 TargetPageType = typeof(Views.Pages.AchievementsPage)
             },
-            /*new NavigationViewItem()
+            new NavigationViewItem()
             {
-                Content = "Stats",
+                Content = "Queue",
+                Icon = new SymbolIcon { Symbol = SymbolRegular.TaskListLtr24 },
+                TargetPageType = typeof(Views.Pages.QueuePage)
+            },
+            new NavigationViewItem()
+            {
+                Content = "Stat Editor",
                 Icon = new SymbolIcon { Symbol = SymbolRegular.DataHistogram24 },
                 TargetPageType = typeof(Views.Pages.StatsPage)
-            },*/
+            },
             new NavigationViewItem()
             {
                 Content = "Misc",

--- a/XAU/Views/Pages/AchievementsPage.xaml
+++ b/XAU/Views/Pages/AchievementsPage.xaml
@@ -17,11 +17,15 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       mc:Ignorable="d">
 
+    <Page.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Page.Resources>
 
     <Grid
           Height="{Binding ElementName=AchievementsPagen, Path=ActualHeight}"
           Width="{Binding ElementName=AchievementsPagen, Path=ActualWidth}">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
@@ -78,7 +82,7 @@
                 Text="{Binding ViewModel.SearchText, Mode=TwoWay, IsAsync=true}"
                 TextAlignment="Center"
                 ClearButtonEnabled="False" 
-                KeyDown="SearchBox_OnKeyDown"
+                KeyDown="SearchBox_OnKeyDownAsync"
             ></ui:TextBox>
             <ui:Button
                 Grid.Row="1"
@@ -138,16 +142,168 @@
                 Command="{Binding ViewModel.RefreshAchievementsCommand}"
             />
         </Grid>
-        <DataGrid Grid.Row="1"  
-                  VerticalScrollBarVisibility="Visible" 
+
+        <Border Grid.Row="1"
+                Margin="0,2,0,10"
+                CornerRadius="12"
+                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                Visibility="{Binding ViewModel.IsAutoUnlockerEnabled, Converter={StaticResource BoolToVis}}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Border Grid.Column="0" Width="4" CornerRadius="12,0,0,12"
+                        Background="{DynamicResource AccentFillColorDefaultBrush}"/>
+
+                <Grid Grid.Column="1" Margin="18,16,18,16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Border Grid.Column="0" Width="34" Height="34" CornerRadius="8"
+                                Margin="0,0,12,0" VerticalAlignment="Center"
+                                Background="{DynamicResource AccentFillColorDefaultBrush}">
+                            <ui:SymbolIcon Symbol="Rocket24" FontSize="18"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+                        </Border>
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                            <ui:TextBlock Text="Auto Unlocker" FontTypography="BodyStrong"/>
+                            <ui:TextBlock Text="Natural-timeline achievement unlocking"
+                                          FontTypography="Caption"
+                                          Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                        </StackPanel>
+                        <ui:ProgressRing Grid.Column="2" Width="20" Height="20" Margin="0,0,10,0"
+                                         IsIndeterminate="True" VerticalAlignment="Center"
+                                         Visibility="{Binding ViewModel.AutoRunning, Converter={StaticResource BoolToVis}}"/>
+                        <Border Grid.Column="3" CornerRadius="11" Padding="12,4" VerticalAlignment="Center"
+                                Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1">
+                            <ui:TextBlock Text="{Binding ViewModel.AutoStatusText}"
+                                          FontTypography="Caption"
+                                          Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                        </Border>
+                    </Grid>
+
+                    <Border Grid.Row="1" Height="1" Margin="0,14,0,14"
+                            Background="{DynamicResource CardStrokeColorDefaultBrush}"/>
+
+                    <StackPanel Grid.Row="2" Orientation="Horizontal">
+                        <ui:Button MinWidth="124" Appearance="Primary"
+                                   Content="{Binding ViewModel.AutoStartPauseLabel}"
+                                   Command="{Binding ViewModel.ToggleAutoUnlockerCommand}"/>
+                        <ui:Button Margin="8,0,0,0" Appearance="Danger"
+                                   Icon="{ui:SymbolIcon Stop24}" Content="Stop"
+                                   Visibility="{Binding ViewModel.AutoRunning, Converter={StaticResource BoolToVis}}"
+                                   Command="{Binding ViewModel.StopAutoUnlockerCommand}"/>
+                        <ui:Button Margin="8,0,0,0" Icon="{ui:SymbolIcon PersonAdd24}"
+                                   Content="Get Unlock Order"
+                                   IsEnabled="{Binding ViewModel.AutoControlsEnabled}"
+                                   Command="{Binding ViewModel.GetUnlockOrderCommand}"/>
+                        <ui:Button Margin="8,0,0,0" Icon="{ui:SymbolIcon TaskListAdd24}"
+                                   Content="Add to Queue"
+                                   IsEnabled="{Binding ViewModel.AutoControlsEnabled}"
+                                   Command="{Binding ViewModel.AddToQueueCommand}"/>
+                    </StackPanel>
+
+                    <Border Grid.Row="3" Margin="0,14,0,0" Padding="14,12" CornerRadius="8"
+                            Background="{DynamicResource ControlFillColorDefaultBrush}"
+                            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1"
+                            Visibility="{Binding ViewModel.AutoRunning, Converter={StaticResource BoolToVis}}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <ui:TextBlock Grid.Row="0" Text="NOW UNLOCKING"
+                                          FontTypography="Caption"
+                                          Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                            <Grid Grid.Row="1" Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Column="0" VerticalAlignment="Center"
+                                              TextTrimming="CharacterEllipsis" FontTypography="BodyStrong"
+                                              Text="{Binding ViewModel.AutoCurrentAchievement}"/>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal"
+                                            Margin="12,0,0,0" VerticalAlignment="Center">
+                                    <ui:SymbolIcon Symbol="Timer24" FontSize="18" Margin="0,0,6,0"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"/>
+                                    <ui:TextBlock VerticalAlignment="Center" FontTypography="Title"
+                                                  Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"
+                                                  Text="{Binding ViewModel.AutoCountdownText}"/>
+                                </StackPanel>
+                            </Grid>
+                            <ProgressBar Grid.Row="2" Margin="0,10,0,0" Height="6"
+                                         Minimum="0" Maximum="1" Value="{Binding ViewModel.AutoProgressValue}"/>
+                            <ui:TextBlock Grid.Row="3" Margin="0,6,0,0" HorizontalAlignment="Right"
+                                          FontTypography="Caption"
+                                          Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                          Text="{Binding ViewModel.AutoEstimateText}"/>
+                        </Grid>
+                    </Border>
+
+                    <Grid Grid.Row="4" Margin="0,14,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <ui:Button Grid.Column="0" Icon="{ui:SymbolIcon Filter24}" Content="Edit Skip List"
+                                   IsEnabled="{Binding ViewModel.AutoControlsEnabled}"
+                                   Command="{Binding ViewModel.EditSkipListCommand}"/>
+                        <ui:Button Grid.Column="1" Margin="8,0,0,0" Icon="{ui:SymbolIcon Timer24}" Content="Edit Delays"
+                                   IsEnabled="{Binding ViewModel.AutoControlsEnabled}"
+                                   Command="{Binding ViewModel.EditDelaysCommand}"/>
+                        <Border Grid.Column="3" CornerRadius="8" Padding="10,4"
+                                Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="ArrowRepeatAll24" FontSize="14" Margin="0,0,6,0"
+                                               VerticalAlignment="Center"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                <ui:TextBlock Text="Loop ×" VerticalAlignment="Center" Margin="0,0,6,0"
+                                              Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                <ui:TextBox Width="46"
+                                            Text="{Binding ViewModel.AutoLoopCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                            ToolTip="Repeat counter-based event achievements this many times (default 1)."/>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <DataGrid Grid.Row="2"
+                  VerticalScrollBarVisibility="Visible"
                   HorizontalScrollBarVisibility="Visible"
-                  Margin="0,5,0,5" 
-                  AutoGenerateColumns="False"  
-                  ItemsSource="{Binding ViewModel.DGAchievements}" 
-                  IsReadOnly="True"
+                  Margin="0,5,0,5"
+                  AutoGenerateColumns="False"
                   EnableRowVirtualization="True"
                   VirtualizingPanel.IsVirtualizing="True"
                   VirtualizingPanel.VirtualizationMode="Recycling"
+                  ItemsSource="{Binding ViewModel.DGAchievements}" 
+                  IsReadOnly="True"
                   CanUserAddRows="False"
                   CanUserDeleteRows="False"
                   CanUserReorderColumns="False"
@@ -177,6 +333,23 @@
                 <DataGridTextColumn Header="Percentage" Binding="{Binding RarityPercentage}" Width="0.13*"/>
                 <DataGridTextColumn Header="Rarity" Binding="{Binding RarityCategory}" Width="0.11*"/>
                 <DataGridTextColumn Header="State" Binding="{Binding ProgressState}" Width="0.12*"/>
+                <!-- Coluna Category: "Easy Unlock"/"Hard Unlock" (vazia em jogos comuns). -->
+                <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="0.16*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="TextWrapping" Value="Wrap" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <!-- Marca de verificação: ✓ confirmado / ⏳ pendente. -->
+                <DataGridTextColumn Header="✓" Binding="{Binding VerifyState}" Width="0.04*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Center" />
+                            <Setter Property="FontSize" Value="14" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
                 <DataGridTemplateColumn Header="Unlock" Width="0.13*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/XAU/Views/Pages/AchievementsPage.xaml.cs
+++ b/XAU/Views/Pages/AchievementsPage.xaml.cs
@@ -32,13 +32,14 @@ namespace XAU.Views.Pages
 
         }
 
-        private void SearchBox_OnKeyDown(object sender, KeyEventArgs e)
+        private async void SearchBox_OnKeyDownAsync(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Enter)
             {
                 //for some reason, the search text is not being updated when pressing enter
                 ViewModel.SearchText = SearchBox.Text;
-                ViewModel.SearchAndFilterAchievements();
+                await ViewModel.SearchAndFilterAchievements();
+
             }
         }
     }

--- a/XAU/Views/Pages/QueuePage.xaml
+++ b/XAU/Views/Pages/QueuePage.xaml
@@ -1,0 +1,266 @@
+<Page
+    x:Class="XAU.Views.Pages.QueuePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:XAU.Views.Pages"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="QueuePage"
+    d:DataContext="{d:DesignInstance local:QueuePage, IsDesignTimeCreatable=False}"
+    d:DesignHeight="760"
+    d:DesignWidth="820"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+    </Page.Resources>
+
+    <Grid Margin="14">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+
+                <TextBlock Text="Game Queue" FontSize="28" FontWeight="Bold" />
+                <TextBlock
+                    Margin="0,2,0,14"
+                    FontSize="14"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="Search a game, mirror a player's unlock order, fine-tune it, then queue it up." />
+
+                <ui:Card Padding="16" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock Text="1 · Find a game" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,10" />
+
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ui:TextBox
+                                Grid.Column="0"
+                                PlaceholderText="Search by game name…"
+                                IsEnabled="{Binding ViewModel.CanEdit, Mode=OneWay}"
+                                Text="{Binding ViewModel.SearchText, UpdateSourceTrigger=PropertyChanged}">
+                                <ui:TextBox.InputBindings>
+                                    <KeyBinding Key="Return" Command="{Binding ViewModel.SearchGamesCommand}" />
+                                </ui:TextBox.InputBindings>
+                            </ui:TextBox>
+                            <ui:Button
+                                Grid.Column="1"
+                                Margin="8,0,0,0"
+                                Content="Search"
+                                Icon="{ui:SymbolIcon Search24}"
+                                IsEnabled="{Binding ViewModel.CanEdit, Mode=OneWay}"
+                                Command="{Binding ViewModel.SearchGamesCommand, Mode=OneWay}" />
+                        </Grid>
+
+                        <ListView
+                            Margin="0,10,0,0"
+                            MaxHeight="190"
+                            BorderThickness="0"
+                            ItemsSource="{Binding ViewModel.SearchResults, Mode=OneWay}"
+                            SelectedItem="{Binding ViewModel.SelectedResult, Mode=TwoWay}">
+                            <ListView.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="0,2">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{Binding Title}" TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                                        <Border Grid.Column="1" Background="#2260CDFF" CornerRadius="4" Padding="6,1" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding TitleId}" FontSize="11" Foreground="#60CDFF" />
+                                        </Border>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+
+                        <StackPanel Visibility="{Binding ViewModel.HasSelection, Converter={StaticResource BoolToVis}}">
+                            <Border Height="1" Background="{DynamicResource ControlStrokeColorDefaultBrush}" Margin="0,14,0,12" />
+                            <TextBlock FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8">
+                                <Run Text="2 · " />
+                                <Run Text="{Binding ViewModel.DraftName, Mode=OneWay}" FontWeight="SemiBold" />
+                            </TextBlock>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBox
+                                    Grid.Column="0"
+                                    PlaceholderText="Reference gamertag  —  whose unlock order to mirror"
+                                    IsEnabled="{Binding ViewModel.CanEdit, Mode=OneWay}"
+                                    Text="{Binding ViewModel.DraftGamertag, UpdateSourceTrigger=PropertyChanged}" />
+                                <ui:Button
+                                    Grid.Column="1"
+                                    Margin="8,0,0,0"
+                                    Appearance="Primary"
+                                    Content="Build Order"
+                                    Icon="{ui:SymbolIcon Wand24}"
+                                    IsEnabled="{Binding ViewModel.CanEdit, Mode=OneWay}"
+                                    Command="{Binding ViewModel.BuildOrderCommand, Mode=OneWay}" />
+                            </Grid>
+                        </StackPanel>
+
+                        <StackPanel Visibility="{Binding ViewModel.HasOrder, Converter={StaticResource BoolToVis}}">
+                            <Border Height="1" Background="{DynamicResource ControlStrokeColorDefaultBrush}" Margin="0,14,0,12" />
+                            <Grid Margin="0,0,0,8">
+                                <TextBlock Text="3 · Unlock order" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+                                <TextBlock
+                                    HorizontalAlignment="Right" VerticalAlignment="Center"
+                                    FontSize="13"
+                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                    Text="{Binding ViewModel.DraftSummary, Mode=OneWay}" />
+                            </Grid>
+
+                            <Border
+                                CornerRadius="6"
+                                Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                Padding="6">
+                                <ScrollViewer MaxHeight="260" VerticalScrollBarVisibility="Auto">
+                                    <ItemsControl ItemsSource="{Binding ViewModel.Preview, Mode=OneWay}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid Margin="4,3" Opacity="{Binding NameOpacity}">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="34" />
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Grid.Column="0" Text="{Binding PositionText}" FontSize="12"
+                                                               Foreground="{DynamicResource TextFillColorTertiaryBrush}" VerticalAlignment="Center" />
+                                                    <TextBlock Grid.Column="1" Text="{Binding Name}" TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                                                    <Border Grid.Column="2" Background="#22FFFFFF" CornerRadius="4" Padding="6,1" VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding DelayText}" FontSize="11" />
+                                                    </Border>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </ScrollViewer>
+                            </Border>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+                                <ui:Button
+                                    Content="Edit Delays"
+                                    Icon="{ui:SymbolIcon Timer24}"
+                                    IsEnabled="{Binding ViewModel.CanEdit, Mode=OneWay}"
+                                    Command="{Binding ViewModel.EditDraftDelaysCommand, Mode=OneWay}" />
+                                <ui:Button
+                                    Margin="8,0,0,0"
+                                    Content="Edit Skip List"
+                                    Icon="{ui:SymbolIcon CheckboxChecked24}"
+                                    IsEnabled="{Binding ViewModel.CanEdit, Mode=OneWay}"
+                                    Command="{Binding ViewModel.EditDraftSkipCommand, Mode=OneWay}" />
+                                <ui:Button
+                                    Margin="8,0,0,0"
+                                    Appearance="Primary"
+                                    Content="Add to Queue"
+                                    Icon="{ui:SymbolIcon AddCircle24}"
+                                    IsEnabled="{Binding ViewModel.CanEdit, Mode=OneWay}"
+                                    Command="{Binding ViewModel.ConfirmAddCommand, Mode=OneWay}" />
+                                <ui:Button
+                                    Margin="8,0,0,0"
+                                    Appearance="Secondary"
+                                    Content="Discard"
+                                    Command="{Binding ViewModel.DiscardDraftCommand, Mode=OneWay}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </ui:Card>
+
+                <ui:Card Padding="16" Margin="0,0,0,12">
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock Text="Delay between games" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                <ui:TextBox
+                                    Width="56" MaxLength="3"
+                                    IsEnabled="{Binding ViewModel.IsIdle, Mode=OneWay}"
+                                    Text="{Binding ViewModel.CooldownMinutes, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock Text="min" VerticalAlignment="Center" Margin="8,0,0,0" />
+                            </StackPanel>
+
+                            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                                <ui:Button
+                                    Appearance="Primary" Content="Start Queue" Icon="{ui:SymbolIcon Play24}"
+                                    IsEnabled="{Binding ViewModel.IsIdle, Mode=OneWay}"
+                                    Command="{Binding ViewModel.StartQueueCommand, Mode=OneWay}" />
+                                <ui:Button
+                                    Margin="8,0,0,0" Content="Stop" Icon="{ui:SymbolIcon Stop24}"
+                                    IsEnabled="{Binding ViewModel.IsRunning, Mode=OneWay}"
+                                    Command="{Binding ViewModel.StopQueueCommand, Mode=OneWay}" />
+                                <ui:Button
+                                    Margin="8,0,0,0" Content="Clear" Icon="{ui:SymbolIcon Delete24}"
+                                    IsEnabled="{Binding ViewModel.IsIdle, Mode=OneWay}"
+                                    Command="{Binding ViewModel.ClearQueueCommand, Mode=OneWay}" />
+                            </StackPanel>
+                        </Grid>
+
+                        <TextBlock Margin="0,10,0,0" FontSize="13"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   Text="{Binding ViewModel.QueueEtaText, Mode=OneWay}" />
+                        <TextBlock Margin="0,4,0,0" FontSize="14" FontWeight="SemiBold" Text="{Binding ViewModel.RunStatus, Mode=OneWay}" />
+                        <TextBlock FontSize="13" Foreground="#60CDFF" Text="{Binding ViewModel.CooldownText, Mode=OneWay}" />
+                    </StackPanel>
+                </ui:Card>
+
+                <ItemsControl ItemsSource="{Binding ViewModel.Games, Mode=OneWay}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <ui:Card Padding="14,10" Margin="0,0,0,8">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding GameName}" FontSize="16" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Text="{Binding EstimateText}" FontSize="12"
+                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                            <ui:SymbolIcon Symbol="Person24" FontSize="13" VerticalAlignment="Center"
+                                                           Foreground="{DynamicResource TextFillColorTertiaryBrush}" />
+                                            <TextBlock Text="{Binding Gamertag}" FontSize="12" Margin="4,0,0,0"
+                                                       Foreground="{DynamicResource TextFillColorTertiaryBrush}" />
+                                        </StackPanel>
+                                    </StackPanel>
+
+                                    <Border Grid.Column="1" VerticalAlignment="Center" Margin="10,0,10,0">
+                                        <TextBlock Text="{Binding Status}" FontSize="13" FontWeight="SemiBold"
+                                                   Foreground="{Binding StatusColor}" />
+                                    </Border>
+
+                                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                                        <ui:Button Padding="8" Margin="2,0" Appearance="Secondary" Icon="{ui:SymbolIcon ChevronUp24}" ToolTip="Move up"
+                                                   Command="{Binding DataContext.ViewModel.MoveUpCommand, RelativeSource={RelativeSource AncestorType={x:Type Page}}}"
+                                                   CommandParameter="{Binding}" />
+                                        <ui:Button Padding="8" Margin="2,0" Appearance="Secondary" Icon="{ui:SymbolIcon ChevronDown24}" ToolTip="Move down"
+                                                   Command="{Binding DataContext.ViewModel.MoveDownCommand, RelativeSource={RelativeSource AncestorType={x:Type Page}}}"
+                                                   CommandParameter="{Binding}" />
+                                        <ui:Button Padding="8" Margin="2,0" Appearance="Secondary" Icon="{ui:SymbolIcon Dismiss24}" ToolTip="Remove"
+                                                   Command="{Binding DataContext.ViewModel.RemoveCommand, RelativeSource={RelativeSource AncestorType={x:Type Page}}}"
+                                                   CommandParameter="{Binding}" />
+                                    </StackPanel>
+                                </Grid>
+                            </ui:Card>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/XAU/Views/Pages/QueuePage.xaml.cs
+++ b/XAU/Views/Pages/QueuePage.xaml.cs
@@ -1,0 +1,17 @@
+using Wpf.Ui.Controls;
+using XAU.ViewModels.Pages;
+
+namespace XAU.Views.Pages
+{
+    public partial class QueuePage : INavigableView<QueueViewModel>
+    {
+        public QueueViewModel ViewModel { get; }
+
+        public QueuePage(QueueViewModel viewModel)
+        {
+            ViewModel = viewModel;
+            DataContext = this;
+            InitializeComponent();
+        }
+    }
+}

--- a/XAU/Views/Pages/SettingsPage.xaml
+++ b/XAU/Views/Pages/SettingsPage.xaml
@@ -35,6 +35,37 @@
                     <ui:TextBlock
                         Grid.Row="0"
                         FontTypography="Body"
+                        Text="Tokens"
+                        TextWrapping="WrapWithOverflow" />
+                    <ui:TextBlock
+                        Grid.Row="1"
+                        Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Copy your current xauth or event token to the clipboard. Sign in first."
+                        TextWrapping="WrapWithOverflow" />
+                </Grid>
+            </ui:CardControl.Header>
+            <StackPanel Orientation="Horizontal">
+                <ui:Button
+                    Icon="{ui:SymbolIcon Copy24}"
+                    Content="Copy xauth"
+                    Command="{Binding ViewModel.CopyXauthCommand}" />
+                <ui:Button
+                    Margin="8,0,0,0"
+                    Icon="{ui:SymbolIcon Copy24}"
+                    Content="Copy Event Token"
+                    Command="{Binding ViewModel.CopyEventTokenCommand}" />
+            </StackPanel>
+        </ui:CardControl>
+        <ui:CardControl Margin="4,2">
+            <ui:CardControl.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <ui:TextBlock
+                        Grid.Row="0"
+                        FontTypography="Body"
                         Text="Enable Unlock All"
                         TextWrapping="WrapWithOverflow" />
                     <ui:TextBlock

--- a/XAU/Views/Pages/StatsPage.xaml
+++ b/XAU/Views/Pages/StatsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="XAU.Views.Pages.StatsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,7 +6,8 @@
     xmlns:local="clr-namespace:XAU.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="Stats Page"
+    Title="Stat Editor"
+    x:Name="StatsPageRoot"
     d:DataContext="{d:DesignInstance local:StatsPage,
                                      IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
@@ -16,7 +17,132 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid>
-        
+    <Page.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Page.Resources>
+
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Top bar: title id + load + filter -->
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="200"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="180"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0"
+                       Text="Title ID"
+                       VerticalAlignment="Center"
+                       Margin="0,0,8,0"/>
+            <ui:TextBox Grid.Column="1"
+                        x:Name="StatTitleIdBox"
+                        Text="{Binding ViewModel.TitleId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        PlaceholderText="e.g. 1234567890"/>
+            <ui:Button Grid.Column="2"
+                       Margin="8,0,0,0"
+                       Content="Load"
+                       Appearance="Primary"
+                       IsEnabled="{Binding ViewModel.NotBusy}"
+                       Command="{Binding ViewModel.LoadStatsCommand}"/>
+            <ui:Button Grid.Column="3"
+                       Margin="6,0,0,0"
+                       ToolTip="Reload stats"
+                       Icon="{ui:SymbolIcon ArrowSync24}"
+                       IsEnabled="{Binding ViewModel.NotBusy}"
+                       Command="{Binding ViewModel.LoadStatsCommand}"/>
+            <ui:TextBox Grid.Column="4"
+                        Margin="12,0,0,0"
+                        x:Name="StatFilterBox"
+                        Text="{Binding ViewModel.FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        PlaceholderText="Filter..."
+                        Icon="{ui:SymbolIcon Search24}"/>
+            <TextBlock Grid.Column="5"
+                       Margin="16,0,0,0"
+                       VerticalAlignment="Center"
+                       Opacity="0.85"
+                       TextTrimming="CharacterEllipsis"
+                       Text="{Binding ViewModel.StatusText}"/>
+        </Grid>
+
+        <ProgressBar Grid.Row="1"
+                     Margin="0,8,0,0"
+                     IsIndeterminate="{Binding ViewModel.IsBusy}"
+                     Visibility="{Binding ViewModel.IsBusy, Converter={StaticResource BoolToVis}}"/>
+
+        <!-- Editable stats grid -->
+        <DataGrid Grid.Row="2"
+                  Margin="0,8,0,0"
+                  AutoGenerateColumns="False"
+                  ItemsSource="{Binding ViewModel.Stats}"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  CanUserReorderColumns="False"
+                  CanUserResizeColumns="True"
+                  CanUserResizeRows="False"
+                  CanUserSortColumns="True"
+                  HeadersVisibility="Column"
+                  VerticalScrollBarVisibility="Visible"
+                  HorizontalScrollBarVisibility="Auto">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Stat" Binding="{Binding DisplayName}" Width="0.34*" IsReadOnly="True">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="TextWrapping" Value="Wrap" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Internal Name" Binding="{Binding Name}" Width="0.24*" IsReadOnly="True">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Opacity" Value="0.7" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Type" Binding="{Binding StatType}" Width="0.12*" IsReadOnly="True">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <!-- Editable value -->
+                <DataGridTextColumn Header="Value" Binding="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="0.18*">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTemplateColumn Header="Save" Width="0.08*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Margin="4"
+                                    Content="Save"
+                                    HorizontalAlignment="Stretch"
+                                    Command="{Binding ViewModel.SaveStatCommand, RelativeSource={RelativeSource AncestorType={x:Type Page}}}"
+                                    CommandParameter="{Binding}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="✓" Binding="{Binding Status}" Width="0.04*" IsReadOnly="True">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Center" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </Page>


### PR DESCRIPTION
## What this adds
- **Auto-unlocker** â€” event/counter-based unlocking with an RTA achievement stream, order repository, unlock verifier, and an Xbox rate limiter (XAU/Services/AutoUnlock/).
- **Stat editor** â€” edit title stats via a new StatEditorService.
- **Unlock queue** â€” queue titles and run them start-to-finish (QueuePage + QueueViewModel).
- **Login/auth** â€” GDK token service, WAM interop, and an OAuth login window feeding the existing WAM auth flow.
- Reworks to Achievements / Home / Settings / Stats view-models and pages to surface the above.

## Notes
- ~5.2k additions, single commit on top of `schlop`.
- Some inline comments are in Portuguese; happy to translate if preferred.
- Built and released cleanly via CI (.NET 9, win-x64 single-file).
